### PR TITLE
Fix CV templates route to load correct view

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::middleware('auth')->group(function () {
         Route::post('/cv/preview','preview')->name('cv.preview');
         Route::post('/cv/pdf','pdf')->name('cv.pdf');
         Route::get('/cv/guide', fn()=> view('cv.guide'))->name('cv.guide');
-        Route::get('/cv/templates', fn()=> view('cv.templates.index'))->name('cv.templates');
+        Route::get('/cv/templates', fn()=> view('templates.index'))->name('cv.templates');
     });
 
     // API endpoints for dynamic dropdowns

--- a/tests/Feature/CvTemplatesTest.php
+++ b/tests/Feature/CvTemplatesTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Models\User;
+
+it('renders the CV templates page for authenticated users', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('/cv/templates');
+
+    $response->assertOk();
+    $response->assertViewIs('templates.index');
+});


### PR DESCRIPTION
## Summary
- point the /cv/templates route at the existing templates.index blade view
- add a feature test ensuring authenticated users can reach the CV templates page

## Testing
- php artisan test *(fails: missing vendor directory and composer install requires GitHub authentication in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d18c2234b48332be4e86e6fe3d017f