### PR TITLE
Revamp CV builder UI and fix city lookup

### DIFF
--- a/app/Http/Controllers/CvController.php
+++ b/app/Http/Controllers/CvController.php
@@ -17,7 +17,12 @@ class CvController extends Controller
         // Example templates list
         $templates = ['classic','modern','creative','minimal','elegant','corporate','gradient','darkmode','futuristic'];
 
-        return view('cv.form', compact('countries', 'templates'));
+        $initialTemplate = request('template');
+        if ($initialTemplate && !in_array($initialTemplate, $templates, true)) {
+            $initialTemplate = null;
+        }
+
+        return view('cv.form', compact('countries', 'templates', 'initialTemplate'));
     }
 
     public function store(Request $request)

--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -1,116 +1,431 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto py-10">
-        <!-- Step Indicator -->
-        <div class="flex justify-between items-center mb-8">
-            @foreach (['1' => 'Personal Info', '2' => 'Education', '3' => 'Experience', '4' => 'Finish'] as $step => $label)
-                <div class="flex-1 text-center">
-                    <div class="w-10 h-10 mx-auto rounded-full flex items-center justify-center 
-                        {{ $loop->first ? 'bg-blue-600 text-white' : 'bg-gray-200 text-gray-700' }}">
-                        {{ $step }}
+    @php
+        $stepItems = [
+            ['title' => 'Personal', 'description' => 'Tell us about yourself'],
+            ['title' => 'Education', 'description' => 'Share your studies'],
+            ['title' => 'Experience', 'description' => 'Add recent roles'],
+            ['title' => 'Template', 'description' => 'Pick a visual style'],
+        ];
+
+        $templateMeta = [
+            'classic' => [
+                'title' => 'Classic',
+                'description' => 'Timeless layout with balanced typography.',
+                'preview' => 'from-slate-200 via-white to-slate-100',
+            ],
+            'modern' => [
+                'title' => 'Modern',
+                'description' => 'Bold headings and confident accents.',
+                'preview' => 'from-blue-200 via-blue-100 to-slate-50',
+            ],
+            'creative' => [
+                'title' => 'Creative',
+                'description' => 'Playful design that stands out.',
+                'preview' => 'from-pink-200 via-purple-200 to-sky-100',
+            ],
+            'minimal' => [
+                'title' => 'Minimal',
+                'description' => 'Clean, airy composition for focus.',
+                'preview' => 'from-white via-slate-50 to-slate-100',
+            ],
+            'elegant' => [
+                'title' => 'Elegant',
+                'description' => 'Subtle serif style with delicate lines.',
+                'preview' => 'from-amber-100 via-rose-50 to-white',
+            ],
+            'corporate' => [
+                'title' => 'Corporate',
+                'description' => 'Structured sections for formal roles.',
+                'preview' => 'from-slate-300 via-slate-200 to-white',
+            ],
+            'gradient' => [
+                'title' => 'Gradient',
+                'description' => 'Vibrant gradients for modern teams.',
+                'preview' => 'from-emerald-200 via-teal-200 to-cyan-100',
+            ],
+            'darkmode' => [
+                'title' => 'Dark Mode',
+                'description' => 'Sleek look with high contrast.',
+                'preview' => 'from-slate-800 via-slate-900 to-black',
+            ],
+            'futuristic' => [
+                'title' => 'Futuristic',
+                'description' => 'Tech-forward blocks and glow.',
+                'preview' => 'from-indigo-300 via-purple-300 to-slate-100',
+            ],
+        ];
+
+        $initialTemplate = old('template', $initialTemplate ?? ($templates[0] ?? 'classic'));
+        $inputClasses = 'mt-1 block w-full rounded-2xl border border-slate-200 bg-white/80 px-4 py-3 text-slate-900 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200/60 focus:outline-none transition';
+    @endphp
+
+    <div class="min-h-screen -mx-4 -mt-8 px-4 py-8 bg-gradient-to-br from-slate-950 via-slate-900 to-black">
+        <div class="max-w-5xl mx-auto">
+            <div class="text-center text-white mb-12">
+                <h1 class="text-4xl md:text-5xl font-semibold tracking-tight">Craft your CV</h1>
+                <p class="mt-3 text-base md:text-lg text-slate-300">Follow the guided steps to build a polished, Apple-inspired resume.</p>
+            </div>
+
+            <div class="bg-white/80 backdrop-blur-2xl shadow-2xl rounded-[32px] p-6 sm:p-10 md:p-12">
+                <div class="mb-12">
+                    <div class="flex flex-col gap-6 md:flex-row md:items-center md:gap-4">
+                        @foreach ($stepItems as $index => $step)
+                            <div class="flex items-center gap-4 md:flex-1">
+                                <button type="button" data-step-trigger="{{ $loop->iteration }}" class="flex flex-col md:flex-row md:items-center text-slate-500 gap-2 transition" aria-label="Step {{ $loop->iteration }}: {{ $step['title'] }}">
+                                    <span data-step-circle class="flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-base font-semibold shadow-sm transition-all duration-300">{{ $loop->iteration }}</span>
+                                    <span class="flex flex-col text-left md:text-left">
+                                        <span class="text-sm font-semibold">{{ $step['title'] }}</span>
+                                        <span class="text-xs text-slate-400">{{ $step['description'] }}</span>
+                                    </span>
+                                </button>
+                                @if (!$loop->last)
+                                    <div data-step-connector="{{ $loop->iteration }}" class="hidden md:block flex-1 h-0.5 bg-slate-200 rounded-full transition-colors duration-300"></div>
+                                @endif
+                            </div>
+                        @endforeach
                     </div>
-                    <p class="text-sm mt-2">{{ $label }}</p>
                 </div>
-            @endforeach
-        </div>
 
-        <!-- Form -->
-        <form method="POST" action="{{ route('cv.store') }}" class="bg-white shadow-lg rounded-xl p-8 space-y-6">
-            @csrf
+                <form method="POST" action="{{ route('cv.store') }}" id="cvForm" class="space-y-10">
+                    @csrf
 
-            <!-- Step 1: Personal Info -->
-            <div>
-                <h2 class="text-xl font-semibold mb-4">Personal Information</h2>
-                <div class="grid grid-cols-2 gap-6">
-                    <div>
-                        <label class="block mb-1 font-medium">First Name</label>
-                        <input type="text" name="first_name" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
+                    <div data-step-panel="1" class="space-y-6">
+                        <div>
+                            <h2 class="text-2xl font-semibold text-slate-900">Personal information</h2>
+                            <p class="text-sm text-slate-500 mt-1">Let&rsquo;s start with the essentials so employers can reach you.</p>
+                        </div>
+
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">First name</label>
+                                <input type="text" name="first_name" value="{{ old('first_name') }}" class="{{ $inputClasses }}" autocomplete="given-name" placeholder="Tim" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Last name</label>
+                                <input type="text" name="last_name" value="{{ old('last_name') }}" class="{{ $inputClasses }}" autocomplete="family-name" placeholder="Cook" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Email</label>
+                                <input type="email" name="email" value="{{ old('email') }}" class="{{ $inputClasses }}" autocomplete="email" placeholder="you@example.com" required>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Phone</label>
+                                <input type="tel" name="phone" value="{{ old('phone') }}" class="{{ $inputClasses }}" autocomplete="tel" placeholder="(+371) 20000000">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Birthday</label>
+                                <input type="date" name="birthday" max="{{ date('Y-m-d') }}" value="{{ old('birthday') }}" class="{{ $inputClasses }}">
+                            </div>
+                            <div class="grid gap-6 md:grid-cols-2 md:col-span-2">
+                                <div>
+                                    <label class="block text-sm font-medium text-slate-600">Country</label>
+                                    <select name="country" id="country" class="{{ $inputClasses }} appearance-none pr-10">
+                                        <option value="">Select country</option>
+                                        @foreach ($countries as $country)
+                                            <option value="{{ $country }}" @selected(old('country', request('country')) === $country)>{{ $country }}</option>
+                                        @endforeach
+                                    </select>
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-slate-600">City</label>
+                                    <select name="city" id="city" class="{{ $inputClasses }} appearance-none pr-10" data-selected-city="{{ old('city') }}">
+                                        <option value="">Select city</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <div>
-                        <label class="block mb-1 font-medium">Last Name</label>
-                        <input type="text" name="last_name" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
+
+                    <div data-step-panel="2" class="space-y-6 hidden">
+                        <div>
+                            <h2 class="text-2xl font-semibold text-slate-900">Education</h2>
+                            <p class="text-sm text-slate-500 mt-1">Highlight your academic background and achievements.</p>
+                        </div>
+
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <div class="md:col-span-2">
+                                <label class="block text-sm font-medium text-slate-600">School / University</label>
+                                <input type="text" name="education[institution]" value="{{ old('education.institution') ?? old('education.school') }}" class="{{ $inputClasses }}" placeholder="Stanford University">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Degree</label>
+                                <input type="text" name="education[degree]" value="{{ old('education.degree') }}" class="{{ $inputClasses }}" placeholder="MBA">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Field of study</label>
+                                <input type="text" name="education[field]" value="{{ old('education.field') }}" class="{{ $inputClasses }}" placeholder="Business Administration">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Start year</label>
+                                <input type="text" name="education[start_year]" value="{{ old('education.start_year') }}" class="{{ $inputClasses }}" placeholder="2017">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Graduation year</label>
+                                <input type="text" name="education[end_year]" value="{{ old('education.end_year') }}" class="{{ $inputClasses }}" placeholder="2021">
+                            </div>
+                        </div>
                     </div>
-                    <div>
-                        <label class="block mb-1 font-medium">Birthday</label>
-                        <input type="date" name="birthday" max="{{ date('Y-m-d') }}" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
+
+                    <div data-step-panel="3" class="space-y-6 hidden">
+                        <div>
+                            <h2 class="text-2xl font-semibold text-slate-900">Experience</h2>
+                            <p class="text-sm text-slate-500 mt-1">Share your most relevant role so far.</p>
+                        </div>
+
+                        <div class="grid gap-6 md:grid-cols-2">
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Role / Position</label>
+                                <input type="text" name="experience[position]" value="{{ old('experience.position') }}" class="{{ $inputClasses }}" placeholder="Product Manager">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Company</label>
+                                <input type="text" name="experience[company]" value="{{ old('experience.company') }}" class="{{ $inputClasses }}" placeholder="Apple">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Country</label>
+                                <input type="text" name="experience[country]" value="{{ old('experience.country') }}" class="{{ $inputClasses }}" placeholder="Latvia">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">City</label>
+                                <input type="text" name="experience[city]" value="{{ old('experience.city') }}" class="{{ $inputClasses }}" placeholder="Rīga">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">Start date</label>
+                                <input type="month" name="experience[from]" value="{{ old('experience.from') }}" class="{{ $inputClasses }}">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-slate-600">End date</label>
+                                <input type="month" id="experience-to" name="experience[to]" value="{{ old('experience.to') }}" class="{{ $inputClasses }}">
+                            </div>
+                            <div class="md:col-span-2 flex items-center gap-3">
+                                <input type="checkbox" id="experience-currently" name="experience[currently]" value="1" class="h-5 w-5 rounded border-slate-300 text-blue-600 focus:ring-blue-500" @checked(old('experience.currently'))>
+                                <label for="experience-currently" class="text-sm text-slate-600">I&rsquo;m currently working in this role</label>
+                            </div>
+                            <div class="md:col-span-2">
+                                <label class="block text-sm font-medium text-slate-600">Key achievements</label>
+                                <textarea name="experience[achievements]" rows="4" class="{{ $inputClasses }}" placeholder="Summarise measurable achievements">{{ old('experience.achievements') }}</textarea>
+                            </div>
+                        </div>
                     </div>
-                    <div>
-                        <label class="block mb-1 font-medium">Country</label>
-                        <select name="country" id="country" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
-                            <option value="">Select Country</option>
-                            @foreach($countries as $country)
-                                <option value="{{ $country }}">{{ $country }}</option>
+
+                    <div data-step-panel="4" class="space-y-8 hidden">
+                        <div>
+                            <h2 class="text-2xl font-semibold text-slate-900">Choose your template</h2>
+                            <p class="text-sm text-slate-500 mt-1">Pick a design that matches your personality. You can always come back and change it.</p>
+                        </div>
+
+                        <div class="grid gap-5 sm:grid-cols-2">
+                            @foreach ($templates as $template)
+                                @php
+                                    $meta = $templateMeta[$template] ?? [
+                                        'title' => ucfirst($template),
+                                        'description' => 'Beautiful layout ready for your story.',
+                                        'preview' => 'from-slate-200 via-white to-slate-100',
+                                    ];
+                                    $inputId = 'template-' . $template;
+                                @endphp
+                                <label for="{{ $inputId }}" data-template-card class="group cursor-pointer">
+                                    <input type="radio" id="{{ $inputId }}" name="template" value="{{ $template }}" class="peer sr-only" @checked($initialTemplate === $template)>
+                                    <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm transition-all duration-300 peer-checked:border-blue-500 peer-checked:shadow-xl peer-checked:shadow-blue-100">
+                                        <div class="flex items-center justify-between gap-4">
+                                            <div>
+                                                <h3 class="text-lg font-semibold text-slate-900">{{ $meta['title'] }}</h3>
+                                                <p class="text-sm text-slate-500 mt-1">{{ $meta['description'] }}</p>
+                                            </div>
+                                            <div class="relative w-24 h-16 rounded-2xl overflow-hidden bg-gradient-to-br {{ $meta['preview'] }} shadow-inner">
+                                                <span class="absolute top-3 left-4 right-4 h-2 rounded-full bg-white/80"></span>
+                                                <span class="absolute top-6 left-4 right-10 h-2 rounded-full bg-white/60"></span>
+                                                <span class="absolute top-9 left-4 right-8 h-2 rounded-full bg-white/40"></span>
+                                                <span class="absolute bottom-4 left-4 right-6 h-8 rounded-xl border border-white/40 bg-white/30"></span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </label>
                             @endforeach
-                        </select>
-                    </div>
-                    <div>
-                        <label class="block mb-1 font-medium">City</label>
-                        <select name="city" id="city" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
-                            <option value="">Select City</option>
-                        </select>
-                    </div>
-                </div>
-            </div>
+                        </div>
 
-            <!-- Step 2: Education -->
-            <div>
-                <h2 class="text-xl font-semibold mb-4">Education</h2>
-                <div class="space-y-4">
-                    <div>
-                        <label class="block mb-1 font-medium">School / University</label>
-                        <input type="text" name="education[school]" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
+                        <div class="rounded-3xl border border-slate-200 bg-white/60 p-6 text-sm text-slate-600">
+                            <p class="font-semibold text-slate-800">What happens next?</p>
+                            <ul class="mt-3 space-y-2 list-disc list-inside">
+                                <li>Review your CV details on the next screen.</li>
+                                <li>Download a polished PDF or return to adjust any step.</li>
+                                <li>Click the circles above at any time to revisit an earlier step.</li>
+                            </ul>
+                        </div>
                     </div>
-                    <div>
-                        <label class="block mb-1 font-medium">Degree</label>
-                        <input type="text" name="education[degree]" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
-                    </div>
-                </div>
-            </div>
 
-            <!-- Step 3: Experience -->
-            <div>
-                <h2 class="text-xl font-semibold mb-4">Experience</h2>
-                <div class="space-y-4">
-                    <div>
-                        <label class="block mb-1 font-medium">Company</label>
-                        <input type="text" name="experience[company]" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
-                    </div>
-                    <div>
-                        <label class="block mb-1 font-medium">Role</label>
-                        <input type="text" name="experience[role]" class="w-full rounded-lg border-gray-300 focus:ring-blue-500">
-                    </div>
-                </div>
-            </div>
+                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-6 border-t border-slate-200">
+                        <button type="button" id="prevStep" class="inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent bg-white px-5 py-3 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg hidden">
+                            <span>&larr;</span>
+                            <span>Previous step</span>
+                        </button>
 
-            <!-- Step 4: Finish -->
-            <div class="text-right">
-                <button type="submit" class="px-6 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition">
-                    Save & Preview
-                </button>
+                        <div class="flex flex-1 sm:flex-initial justify-end gap-3">
+                            <button type="button" id="nextStep" class="inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent bg-slate-900 px-6 py-3 text-sm font-medium text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-black">
+                                <span>Next step</span>
+                                <span>&rarr;</span>
+                            </button>
+                            <button type="submit" id="submitStep" class="hidden inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-blue-700">
+                                <span>Save &amp; preview</span>
+                            </button>
+                        </div>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
     </div>
 
     <script>
-        document.getElementById('country').addEventListener('change', function () {
-            const country = this.value;
-            const cityDropdown = document.getElementById('city');
-            cityDropdown.innerHTML = '<option value="">Loading...</option>';
+        document.addEventListener('DOMContentLoaded', () => {
+            const stepButtons = Array.from(document.querySelectorAll('[data-step-trigger]'));
+            const stepPanels = Array.from(document.querySelectorAll('[data-step-panel]'));
+            const connectors = Array.from(document.querySelectorAll('[data-step-connector]'));
+            const nextButton = document.getElementById('nextStep');
+            const prevButton = document.getElementById('prevStep');
+            const submitButton = document.getElementById('submitStep');
+            const totalSteps = stepPanels.length;
+            let currentStep = 1;
+            let maxStepVisited = 1;
 
-            if (country) {
-                fetch(`/api/cities/${country}`)
-                    .then(res => res.json())
-                    .then(data => {
-                        cityDropdown.innerHTML = '<option value="">Select City</option>';
-                        data.forEach(city => {
-                            let option = document.createElement('option');
-                            option.value = city;
-                            option.textContent = city;
-                            cityDropdown.appendChild(option);
-                        });
-                    })
-                    .catch(() => {
-                        cityDropdown.innerHTML = '<option value="">Error loading cities</option>';
+            function updateStepVisuals() {
+                stepButtons.forEach(button => {
+                    const step = Number(button.dataset.stepTrigger);
+                    const circle = button.querySelector('[data-step-circle]');
+                    button.classList.toggle('text-slate-900', step === currentStep);
+                    button.classList.toggle('text-slate-400', step !== currentStep);
+                    button.classList.toggle('cursor-pointer', step <= maxStepVisited);
+                    button.classList.toggle('cursor-not-allowed', step > maxStepVisited);
+                    button.disabled = step > maxStepVisited;
+
+                    if (circle) {
+                        circle.className = 'flex h-12 w-12 items-center justify-center rounded-full border text-base font-semibold shadow-sm transition-all duration-300';
+                        if (step < currentStep) {
+                            circle.classList.add('bg-blue-600', 'text-white', 'border-blue-600', 'shadow-blue-200');
+                        } else if (step === currentStep) {
+                            circle.classList.add('bg-black', 'text-white', 'border-black', 'ring', 'ring-blue-100');
+                        } else {
+                            circle.classList.add('bg-white', 'text-slate-400', 'border-slate-200');
+                        }
+                    }
+                });
+
+                connectors.forEach(connector => {
+                    const index = Number(connector.dataset.stepConnector);
+                    connector.classList.toggle('bg-blue-500', index < currentStep);
+                    connector.classList.toggle('bg-slate-200', index >= currentStep);
+                });
+
+                stepPanels.forEach(panel => {
+                    const step = Number(panel.dataset.stepPanel);
+                    if (step === currentStep) {
+                        panel.classList.remove('hidden');
+                    } else {
+                        panel.classList.add('hidden');
+                    }
+                });
+
+                prevButton.classList.toggle('hidden', currentStep === 1);
+                nextButton.classList.toggle('hidden', currentStep === totalSteps);
+                submitButton.classList.toggle('hidden', currentStep !== totalSteps);
+            }
+
+            stepButtons.forEach(button => {
+                button.addEventListener('click', () => {
+                    const targetStep = Number(button.dataset.stepTrigger);
+                    if (targetStep <= maxStepVisited) {
+                        currentStep = targetStep;
+                        updateStepVisuals();
+                    }
+                });
+            });
+
+            nextButton.addEventListener('click', () => {
+                if (currentStep < totalSteps) {
+                    currentStep += 1;
+                    maxStepVisited = Math.max(maxStepVisited, currentStep);
+                    updateStepVisuals();
+                }
+            });
+
+            prevButton.addEventListener('click', () => {
+                if (currentStep > 1) {
+                    currentStep -= 1;
+                    updateStepVisuals();
+                }
+            });
+
+            updateStepVisuals();
+
+            // Country and city dynamic behaviour
+            const countrySelect = document.getElementById('country');
+            const citySelect = document.getElementById('city');
+            const preselectedCountry = countrySelect ? countrySelect.value : null;
+            let rememberedCity = citySelect ? citySelect.dataset.selectedCity || null : null;
+
+            async function fetchCities(country, selectedCity = rememberedCity) {
+                if (!country || !citySelect) {
+                    return;
+                }
+
+                citySelect.innerHTML = '<option value="">Loading...</option>';
+
+                try {
+                    const response = await fetch(`/api/cities?country=${encodeURIComponent(country)}`);
+                    if (!response.ok) {
+                        throw new Error('Failed to fetch cities');
+                    }
+                    const cities = await response.json();
+                    citySelect.innerHTML = '<option value="">Select city</option>';
+                    cities.forEach(city => {
+                        const option = document.createElement('option');
+                        option.value = city;
+                        option.textContent = city;
+                        if (selectedCity && selectedCity === city) {
+                            option.selected = true;
+                        }
+                        citySelect.appendChild(option);
                     });
+                } catch (error) {
+                    citySelect.innerHTML = '<option value="">Unable to load cities</option>';
+                }
+            }
+
+            if (countrySelect) {
+                countrySelect.addEventListener('change', () => {
+                    const selected = countrySelect.value;
+                    rememberedCity = null;
+                    citySelect.dataset.selectedCity = '';
+                    if (selected) {
+                        fetchCities(selected, rememberedCity);
+                    } else if (citySelect) {
+                        citySelect.innerHTML = '<option value="">Select city</option>';
+                    }
+                });
+
+                if (preselectedCountry) {
+                    fetchCities(preselectedCountry, rememberedCity);
+                }
+            }
+
+            if (citySelect) {
+                citySelect.addEventListener('change', () => {
+                    rememberedCity = citySelect.value || null;
+                });
+            }
+
+            const currentlyCheckbox = document.getElementById('experience-currently');
+            const experienceToInput = document.getElementById('experience-to');
+            if (currentlyCheckbox && experienceToInput) {
+                const toggleEndDate = () => {
+                    const isChecked = currentlyCheckbox.checked;
+                    experienceToInput.disabled = isChecked;
+                    experienceToInput.classList.toggle('opacity-60', isChecked);
+                    if (isChecked) {
+                        experienceToInput.value = '';
+                    }
+                };
+                currentlyCheckbox.addEventListener('change', toggleEndDate);
+                toggleEndDate();
             }
         });
     </script>

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -1,29 +1,108 @@
 <x-app-layout>
-    <div class="container mx-auto py-8">
-        <h1 class="text-3xl font-bold mb-6">CV Templates</h1>
-        <p class="mb-4">
-            Choose a template for your CV. Click "Use Template" to start editing.
-        </p>
+    @php
+        $templateMeta = [
+            'classic' => [
+                'title' => 'Classic',
+                'description' => 'A timeless layout for any industry.',
+                'preview' => 'from-slate-200 via-white to-slate-100',
+            ],
+            'modern' => [
+                'title' => 'Modern',
+                'description' => 'Bold typography with confident accents.',
+                'preview' => 'from-blue-200 via-blue-100 to-slate-50',
+            ],
+            'creative' => [
+                'title' => 'Creative',
+                'description' => 'Playful composition for imaginative roles.',
+                'preview' => 'from-pink-200 via-purple-200 to-sky-100',
+            ],
+            'minimal' => [
+                'title' => 'Minimal',
+                'description' => 'Crisp, airy layout that lets content breathe.',
+                'preview' => 'from-white via-slate-50 to-slate-100',
+            ],
+            'elegant' => [
+                'title' => 'Elegant',
+                'description' => 'Serif details and refined dividers.',
+                'preview' => 'from-amber-100 via-rose-50 to-white',
+            ],
+            'corporate' => [
+                'title' => 'Corporate',
+                'description' => 'Structured sections for senior roles.',
+                'preview' => 'from-slate-300 via-slate-200 to-white',
+            ],
+            'gradient' => [
+                'title' => 'Gradient',
+                'description' => 'Colourful blend that feels dynamic.',
+                'preview' => 'from-emerald-200 via-teal-200 to-cyan-100',
+            ],
+            'darkmode' => [
+                'title' => 'Dark Mode',
+                'description' => 'High-contrast styling that stands out.',
+                'preview' => 'from-slate-900 via-slate-800 to-black',
+            ],
+            'futuristic' => [
+                'title' => 'Futuristic',
+                'description' => 'Tech inspired shapes and glow.',
+                'preview' => 'from-indigo-300 via-purple-300 to-slate-100',
+            ],
+        ];
+    @endphp
 
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            <!-- Example template card -->
-            <div class="border rounded shadow p-4 flex flex-col justify-between">
-                <h2 class="font-semibold mb-2">Classic Template</h2>
-                <p class="text-sm mb-4">A clean and professional layout suitable for most industries.</p>
-                <a href="{{ route('cv.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded self-start">Use Template</a>
+    <div class="space-y-10">
+        <div class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-950 via-slate-900 to-black p-10 text-white shadow-2xl">
+            <div class="max-w-3xl">
+                <h1 class="text-4xl font-semibold tracking-tight">Choose your CV template</h1>
+                <p class="mt-4 text-lg text-slate-300">Browse our curated selection of templates. Each style is ready to showcase your story beautifully, and you can switch designs at any time during editing.</p>
+                <div class="mt-6 inline-flex items-center gap-3 rounded-full bg-white/10 px-5 py-2 text-sm text-slate-200 backdrop-blur">
+                    <span class="inline-flex h-3 w-3 rounded-full bg-emerald-400"></span>
+                    Templates render instantly when you open the CV builder.
+                </div>
             </div>
+            <div class="pointer-events-none absolute -right-16 -bottom-16 h-64 w-64 rounded-full bg-blue-500/40 blur-3xl"></div>
+        </div>
 
-            <div class="border rounded shadow p-4 flex flex-col justify-between">
-                <h2 class="font-semibold mb-2">Modern Template</h2>
-                <p class="text-sm mb-4">A modern layout with emphasis on skills and achievements.</p>
-                <a href="{{ route('cv.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded self-start">Use Template</a>
-            </div>
-
-            <div class="border rounded shadow p-4 flex flex-col justify-between">
-                <h2 class="font-semibold mb-2">Minimal Template</h2>
-                <p class="text-sm mb-4">Simple, minimal design focusing on content clarity.</p>
-                <a href="{{ route('cv.create') }}" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded self-start">Use Template</a>
-            </div>
+        <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            @foreach ($templates as $template)
+                @php
+                    $meta = $templateMeta[$template] ?? [
+                        'title' => ucfirst($template),
+                        'description' => 'Beautiful layout ready for your details.',
+                        'preview' => 'from-slate-200 via-white to-slate-100',
+                    ];
+                @endphp
+                <div class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-2xl">
+                    <div class="relative h-48 bg-gradient-to-br {{ $meta['preview'] }}">
+                        <div class="absolute inset-0 flex items-center justify-center">
+                            <div class="w-40 rounded-2xl bg-white/80 p-4 shadow-xl shadow-slate-300/50">
+                                <div class="h-2 w-24 rounded-full bg-slate-200"></div>
+                                <div class="mt-3 space-y-2">
+                                    <div class="h-2 w-28 rounded-full bg-slate-300"></div>
+                                    <div class="h-2 w-32 rounded-full bg-slate-200"></div>
+                                    <div class="h-16 rounded-2xl border border-slate-100 bg-slate-50"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="absolute top-4 right-4 flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-slate-600 shadow-sm">
+                            <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                            Preview ready
+                        </div>
+                    </div>
+                    <div class="flex flex-1 flex-col gap-4 p-6">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">{{ $meta['title'] }}</h2>
+                            <p class="mt-2 text-sm text-slate-500">{{ $meta['description'] }}</p>
+                        </div>
+                        <div class="mt-auto flex flex-wrap items-center justify-between gap-3">
+                            <a href="{{ route('cv.create', ['template' => $template]) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition group-hover:bg-black">
+                                Use template
+                                <span aria-hidden="true">&rarr;</span>
+                            </a>
+                            <span class="text-xs uppercase tracking-[0.2em] text-slate-400">{{ strtoupper($template) }}</span>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
         </div>
     </div>
 </x-app-layout>


### PR DESCRIPTION
## Summary
- redesign the CV creation form with an Apple-inspired multi-step wizard, clickable stepper, and richer personal data capture including live city loading
- surface template metadata inside the builder for easier selection and highlight chosen designs with visual previews
- enhance the template gallery with gradient previews and wire template links to preselect designs when opening the form

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d190ed4db4833288af0f2904a4e4b1