### PR TITLE
Add CV history management and remove Instagram login

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -41,12 +41,6 @@ return [
         'redirect' => env('GOOGLE_REDIRECT_URI'),
     ],
 
-    'instagram' => [
-        'client_id' => env('INSTAGRAM_CLIENT_ID'),
-        'client_secret' => env('INSTAGRAM_CLIENT_SECRET'),
-        'redirect' => env('INSTAGRAM_REDIRECT_URI'),
-    ],
-
     'companies_api' => [
         'key' => env('COMPANIES_API_KEY'),
     ],

--- a/database/factories/CvFactory.php
+++ b/database/factories/CvFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cv;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Cv>
+ */
+class CvFactory extends Factory
+{
+    protected $model = Cv::class;
+
+    public function definition(): array
+    {
+        $templates = ['classic', 'modern', 'creative', 'minimal', 'elegant', 'corporate', 'gradient', 'darkmode', 'futuristic'];
+
+        $startYear = $this->faker->numberBetween(2000, 2015);
+        $endYear = $startYear + $this->faker->numberBetween(1, 4);
+        $fromDate = $this->faker->dateTimeBetween('-6 years', '-3 years');
+        $toDate = $this->faker->dateTimeBetween($fromDate, '-1 years');
+
+        return [
+            'user_id' => User::factory(),
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'birthday' => $this->faker->date(),
+            'country' => $this->faker->country(),
+            'city' => $this->faker->city(),
+            'template' => $this->faker->randomElement($templates),
+            'education' => [
+                [
+                    'institution' => $this->faker->company() . ' University',
+                    'degree' => 'BSc',
+                    'field' => $this->faker->randomElement(['Computer Science', 'Business', 'Design']),
+                    'country' => $this->faker->country(),
+                    'city' => $this->faker->city(),
+                    'start_year' => (string) $startYear,
+                    'end_year' => (string) $endYear,
+                ],
+            ],
+            'work_experience' => [
+                [
+                    'position' => $this->faker->jobTitle(),
+                    'company' => $this->faker->company(),
+                    'country' => $this->faker->country(),
+                    'city' => $this->faker->city(),
+                    'from' => $fromDate->format('Y-m'),
+                    'to' => $toDate->format('Y-m'),
+                    'currently' => false,
+                    'achievements' => $this->faker->sentence(),
+                ],
+            ],
+            'hobbies' => $this->faker->words(3),
+        ];
+    }
+}

--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -120,23 +120,31 @@
     }
 
     .createit-social {
-        @apply space-y-3;
+        @apply space-y-4;
     }
 
     .createit-social__button {
-        @apply flex w-full items-center justify-center gap-3 rounded-full border px-4 py-3 text-sm font-semibold transition;
+        @apply flex w-full items-center gap-4 rounded-2xl border border-slate-200 bg-white/95 px-4 py-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring focus:ring-blue-200/60;
     }
 
     .createit-social__button--google {
-        @apply border-slate-200 bg-white text-slate-700 hover:-translate-y-0.5 hover:border-violet-500 hover:text-violet-600 hover:shadow-lg;
-    }
-
-    .createit-social__button--instagram {
-        @apply border-transparent bg-pink-500 text-white hover:-translate-y-0.5 hover:bg-pink-600 hover:shadow-lg;
+        @apply hover:border-blue-500;
     }
 
     .createit-social__icon {
-        @apply inline-flex h-5 w-5 items-center justify-center;
+        @apply inline-flex h-10 w-10 items-center justify-center rounded-xl bg-white text-slate-900 shadow;
+    }
+
+    .createit-social__text {
+        @apply flex flex-col;
+    }
+
+    .createit-social__title {
+        @apply text-sm font-semibold text-slate-800;
+    }
+
+    .createit-social__subtitle {
+        @apply text-xs text-slate-500;
     }
 
     .createit-divider {

--- a/resources/views/components/auth/social-providers.blade.php
+++ b/resources/views/components/auth/social-providers.blade.php
@@ -4,8 +4,10 @@
 
 @php
     $intent = in_array($intent, ['login', 'register'], true) ? $intent : 'login';
-    $googleLabel = $intent === 'register' ? __('Sign up with Google') : __('Continue with Google');
-    $instagramLabel = $intent === 'register' ? __('Sign up with Instagram') : __('Continue with Instagram');
+    $googleLabel = $intent === 'register' ? __('Create account with Google') : __('Continue with Google');
+    $googleHint = $intent === 'register'
+        ? __('We’ll help you start faster by importing your name and avatar.')
+        : __('Skip the password and jump straight back into your workspace.');
 @endphp
 
 <div {{ $attributes->class(['createit-social']) }}>
@@ -17,22 +19,13 @@
             <svg viewBox="0 0 24 24" aria-hidden="true" class="h-5 w-5">
                 <path fill="#EA4335" d="M12 10.8v3.84h5.34a4.624 4.624 0 0 1-2 3.03l3.23 2.51c1.88-1.73 2.96-4.28 2.96-7.31 0-.7-.06-1.37-.18-2.02z" />
                 <path fill="#34A853" d="M4.88 14.32l-.75.57-2.58 2C3.4 20.9 7.34 23.5 12 23.5c3.24 0 5.96-1.07 7.95-2.89l-3.23-2.51c-.89.6-2.03.96-3.72.96-2.86 0-5.29-1.93-6.16-4.52z" />
-                <path fill="#4A90E2" d="M4.88 9.68a7.2 7.2 0 0 1 0-4.36V4.75L2.3 2.72A11.96 11.96 0 0 0 0 12c0 1.94.46 3.78 1.3 5.28l3.58-2.96a7.17 7.17 0 0 1 0-4.64z" />
+                <path fill="#4A90E2" d="M4.88 9.68a7.2 7.2 0 0 1 0-4.36V4.75L2.3 2.72A11.96 11.96 0 0 0 0 12c0 1.94.46 3.78 1.35 5.28l3.58-2.96a7.17 7.17 0 0 1 0-4.64z" />
                 <path fill="#FBBC05" d="M12 4.5c1.77 0 2.97.76 3.65 1.4l2.67-2.62C17.96 1.18 15.24 0 12 0 7.34 0 3.4 2.6 1.3 6.72l3.58 2.96C5.83 6.43 8.26 4.5 12 4.5z" />
             </svg>
         </span>
-        {{ $googleLabel }}
-    </a>
-
-    <a
-        href="{{ route('oauth.redirect', ['provider' => 'instagram', 'intent' => $intent]) }}"
-        class="createit-social__button createit-social__button--instagram"
-    >
-        <span class="createit-social__icon">
-            <svg viewBox="0 0 24 24" aria-hidden="true" class="h-5 w-5 fill-current">
-                <path d="M7 2C4.243 2 2 4.243 2 7v10c0 2.757 2.243 5 5 5h10c2.757 0 5-2.243 5-5V7c0-2.757-2.243-5-5-5H7zm0 2h10c1.654 0 3 1.346 3 3v10c0 1.654-1.346 3-3 3H7c-1.654 0-3-1.346-3-3V7c0-1.654 1.346-3 3-3zm10 1a1 1 0 1 0 0 2 1 1 0 0 0 0-2zm-5 2a5 5 0 1 0 0 10 5 5 0 0 0 0-10zm0 2a3 3 0 1 1 0 6 3 3 0 0 1 0-6z" />
-            </svg>
+        <span class="createit-social__text">
+            <span class="createit-social__title">{{ $googleLabel }}</span>
+            <span class="createit-social__subtitle">{{ $googleHint }}</span>
         </span>
-        {{ $instagramLabel }}
     </a>
 </div>

--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -1,5 +1,28 @@
 <x-app-layout>
     @php
+        $isEditing = $isEditing ?? false;
+        $formAction = $formAction ?? route('cv.store');
+        $formMethod = strtoupper($formMethod ?? 'POST');
+        $badgeLabel = $isEditing ? __('Editing saved CV') : __('Guided builder');
+        $headline = $isEditing ? __('Update your CV') : __('Craft your CV');
+        $heroSubtitle = $isEditing
+            ? __('Refresh sections, tweak your design, and save a polished revision.')
+            : __('Follow the guided steps to build a polished resume with live templates and smart defaults.');
+        $submitLabel = $isEditing ? __('Update & preview') : __('Save & preview');
+        $editingTitle = null;
+        if ($isEditing && ($prefill ?? null)) {
+            $editingTitle = collect([
+                data_get($prefill, 'first_name'),
+                data_get($prefill, 'last_name'),
+            ])->filter(fn($value) => is_string($value) && trim($value) !== '')
+                ->map(fn($value) => trim($value))
+                ->implode(' ');
+
+            if ($editingTitle === '') {
+                $editingTitle = __('Untitled CV');
+            }
+        }
+
         $stepItems = [
             ['title' => 'Personal', 'description' => 'Tell us about yourself'],
             ['title' => 'Education', 'description' => 'Share your studies'],
@@ -152,10 +175,13 @@
             <div class="text-center text-slate-900 mb-12">
                 <div class="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-slate-500 shadow-sm">
                     <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-                    {{ __('Guided builder') }}
+                    {{ $badgeLabel }}
                 </div>
-                <h1 class="mt-5 text-4xl md:text-5xl font-semibold tracking-tight">Craft your CV</h1>
-                <p class="mt-3 text-base md:text-lg text-slate-500">Follow the guided steps to build a polished resume with live templates and smart defaults.</p>
+                <h1 class="mt-5 text-4xl md:text-5xl font-semibold tracking-tight">{{ $headline }}</h1>
+                <p class="mt-3 text-base md:text-lg text-slate-500">{{ $heroSubtitle }}</p>
+                @if ($isEditing && $editingTitle)
+                    <p class="mt-2 text-sm font-medium text-slate-500">{{ __('Working on: :title', ['title' => $editingTitle]) }}</p>
+                @endif
             </div>
 
             @if ($errors->any())
@@ -189,8 +215,11 @@
                     </div>
                 </div>
 
-                <form method="POST" action="{{ route('cv.store') }}" id="cvForm" class="space-y-10">
+                <form method="POST" action="{{ $formAction }}" id="cvForm" class="space-y-10">
                     @csrf
+                    @if ($formMethod !== 'POST')
+                        @method($formMethod)
+                    @endif
 
                     <div data-step-panel="1" class="space-y-6">
                         <div>
@@ -516,7 +545,7 @@
                                 <span>&rarr;</span>
                             </button>
                             <button type="submit" id="submitStep" class="hidden inline-flex items-center justify-center gap-2 rounded-2xl border border-transparent bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-blue-700">
-                                <span>Save &amp; preview</span>
+                                <span>{{ $submitLabel }}</span>
                             </button>
                         </div>
                     </div>

--- a/resources/views/cv/history.blade.php
+++ b/resources/views/cv/history.blade.php
@@ -1,0 +1,111 @@
+<x-app-layout>
+    @php
+        use Illuminate\Support\Str;
+
+        $entries = collect($entries ?? []);
+        $totalCount = $entries->count();
+        $subtitle = $totalCount > 0
+            ? trans_choice('Keep track of :count saved CV|Keep track of :count saved CVs', $totalCount, ['count' => $totalCount])
+            : __('Start by crafting a CV and every version you save will appear here.');
+    @endphp
+
+    <div class="space-y-10">
+        <div class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-sm">
+            <div class="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+                <div>
+                    <p class="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400">{{ __('CV history') }}</p>
+                    <h1 class="mt-3 text-3xl font-semibold text-slate-900">{{ __('Saved CV library') }}</h1>
+                    <p class="mt-2 text-sm text-slate-500">{{ $subtitle }}</p>
+                </div>
+                <div class="flex flex-wrap gap-3">
+                    <a href="{{ route('cv.create') }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-blue-700">
+                        {{ __('Create new CV') }}
+                    </a>
+                    <a href="{{ route('cv.templates') }}" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 bg-white px-5 py-3 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-blue-500 hover:text-blue-600">
+                        {{ __('Browse templates') }}
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        @if (session('status'))
+            <div class="rounded-3xl border border-emerald-200 bg-emerald-50/80 px-6 py-4 text-sm text-emerald-700 shadow-sm">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        @if ($entries->isEmpty())
+            <div class="rounded-3xl border border-dashed border-slate-300 bg-white/70 p-10 text-center shadow-sm">
+                <div class="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-blue-100 text-blue-500">
+                    <svg viewBox="0 0 24 24" aria-hidden="true" class="h-8 w-8"><path fill="currentColor" d="M6 3a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3H6Zm0 2h12a1 1 0 0 1 1 1v8.17l-3.41-3.41a2 2 0 0 0-2.83 0L10 14.17l-1.76-1.76a2 2 0 0 0-2.83 0L5 12.83V6a1 1 0 0 1 1-1Zm9 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4Z"/></svg>
+                </div>
+                <h2 class="mt-6 text-2xl font-semibold text-slate-900">{{ __('No CVs saved yet') }}</h2>
+                <p class="mt-3 text-sm text-slate-500">{{ __('Once you save a CV it will appear here with quick edit and delete actions.') }}</p>
+                <a href="{{ route('cv.create') }}" class="mt-6 inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow transition hover:-translate-y-0.5 hover:bg-black">
+                    {{ __('Start building') }}
+                </a>
+            </div>
+        @else
+            <div class="space-y-6">
+                @foreach ($entries as $entry)
+                    @php
+                        /** @var \App\Models\Cv $cv */
+                        $cv = $entry['cv'];
+                        $templateName = Str::of($entry['template'] ?? 'classic')->headline();
+                        $updatedHuman = optional($entry['updated_at'])->diffForHumans() ?? __('just now');
+                        $createdDate = optional($entry['created_at'])->toFormattedDateString();
+                        $educationLabel = trans_choice(':count education entry|:count education entries', $entry['education_count'], ['count' => $entry['education_count']]);
+                        $experienceLabel = trans_choice(':count experience entry|:count experience entries', $entry['experience_count'], ['count' => $entry['experience_count']]);
+                        $hobbyLabel = trans_choice(':count hobby|:count hobbies', $entry['hobby_count'], ['count' => $entry['hobby_count']]);
+                    @endphp
+
+                    <div class="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg">
+                        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                                <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Template') }} · {{ $templateName }}</p>
+                                <h3 class="mt-2 text-xl font-semibold text-slate-900">{{ $entry['title'] }}</h3>
+                                @if (!empty($entry['email']))
+                                    <p class="text-sm text-slate-500">{{ $entry['email'] }}</p>
+                                @endif
+                                @if ($createdDate)
+                                    <p class="mt-2 text-xs text-slate-400">{{ __('Created :date', ['date' => $createdDate]) }}</p>
+                                @endif
+                            </div>
+                            <div class="rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+                                {{ __('Updated :time', ['time' => $updatedHuman]) }}
+                            </div>
+                        </div>
+
+                        <div class="mt-5 flex flex-wrap gap-3 text-xs text-slate-600">
+                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                <span class="inline-flex h-2 w-2 rounded-full bg-blue-500"></span>
+                                {{ $educationLabel }}
+                            </span>
+                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                <span class="inline-flex h-2 w-2 rounded-full bg-purple-500"></span>
+                                {{ $experienceLabel }}
+                            </span>
+                            <span class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1">
+                                <span class="inline-flex h-2 w-2 rounded-full bg-rose-500"></span>
+                                {{ $hobbyLabel }}
+                            </span>
+                        </div>
+
+                        <div class="mt-6 flex flex-wrap gap-3">
+                            <a href="{{ route('cv.edit', $cv) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow transition hover:-translate-y-0.5 hover:bg-blue-700">
+                                {{ __('Edit CV') }}
+                            </a>
+                            <form method="POST" action="{{ route('cv.destroy', $cv) }}" class="inline-flex" onsubmit="return confirm('{{ __('Are you sure you want to delete this CV?') }}');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 px-5 py-2.5 text-sm font-medium text-slate-600 transition hover:-translate-y-0.5 hover:border-red-400 hover:text-red-600">
+                                    {{ __('Delete') }}
+                                </button>
+                            </form>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </div>
+</x-app-layout>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -5,8 +5,9 @@
         <h2 class="text-3xl font-bold mb-6">Dashboard</h2>
         <p class="text-gray-600 mb-8">Manage your CVs and profile settings.</p>
 
-        <div class="grid sm:grid-cols-3 gap-6">
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
             <a href="{{ route('cv.create') }}" class="block bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-4 rounded-lg shadow hover:opacity-90">Create CV</a>
+            <a href="{{ route('cv.history') }}" class="block bg-gradient-to-r from-slate-600 to-slate-800 text-white py-4 rounded-lg shadow hover:opacity-90">CV History</a>
             <a href="{{ route('cv.guide') }}" class="block bg-gradient-to-r from-gray-500 to-gray-700 text-white py-4 rounded-lg shadow hover:opacity-90">CV Guide</a>
             <a href="{{ route('cv.templates') }}" class="block bg-gradient-to-r from-green-500 to-emerald-600 text-white py-4 rounded-lg shadow hover:opacity-90">CV Templates</a>
         </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -14,6 +14,7 @@
             @auth
                 <a href="{{ route('dashboard') }}" class="createit-navbar__link">Dashboard</a>
                 <a href="{{ route('cv.create') }}" class="createit-navbar__link">Create CV</a>
+                <a href="{{ route('cv.history') }}" class="createit-navbar__link">History</a>
                 <a href="{{ route('cv.guide') }}" class="createit-navbar__link">Guide</a>
                 <a href="{{ route('cv.templates') }}" class="createit-navbar__link">Templates</a>
                 <a href="{{ route('profile.edit') }}" class="createit-navbar__link">Profile</a>

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -39,12 +39,12 @@ Route::middleware('guest')->group(function () {
 Route::prefix('oauth')->name('oauth.')->group(function () {
     Route::middleware('guest')->group(function () {
         Route::get('{provider}/redirect', [SocialLoginController::class, 'redirect'])
-            ->whereIn('provider', ['google', 'instagram'])
+            ->whereIn('provider', ['google'])
             ->name('redirect');
     });
 
     Route::match(['get', 'post'], '{provider}/callback', [SocialLoginController::class, 'callback'])
-        ->whereIn('provider', ['google', 'instagram'])
+        ->whereIn('provider', ['google'])
         ->name('callback');
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,10 @@ Route::middleware('auth')->group(function () {
     Route::prefix('cv')->controller(CvController::class)->group(function () {
         Route::get('/create','create')->name('cv.create');
         Route::post('/store','store')->name('cv.store');
+        Route::get('/history','history')->name('cv.history');
+        Route::get('/{cv}/edit','edit')->name('cv.edit');
+        Route::put('/{cv}','update')->name('cv.update');
+        Route::delete('/{cv}','destroy')->name('cv.destroy');
         Route::get('/preview','preview')->name('cv.preview');
         Route::get('/templates','templates')->name('cv.templates');
         Route::get('/download/{template}','download')->name('cv.download');

--- a/tests/Feature/CvManagementTest.php
+++ b/tests/Feature/CvManagementTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Cv;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CvManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_form_does_not_prefill_existing_cv(): void
+    {
+        $user = User::factory()->create();
+        Cv::factory()->for($user)->create([
+            'first_name' => 'Existing',
+            'last_name' => 'Person',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('cv.create'));
+
+        $response->assertOk();
+        $response->assertViewHas('prefill', null);
+        $response->assertDontSee('Existing');
+    }
+
+    public function test_history_page_lists_only_authenticated_users_cvs(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $firstCv = Cv::factory()->for($user)->create([
+            'first_name' => 'Alice',
+            'last_name' => 'Writer',
+        ]);
+
+        $secondCv = Cv::factory()->for($user)->create([
+            'first_name' => 'Bob',
+            'last_name' => 'Designer',
+        ]);
+
+        Cv::factory()->for($otherUser)->create([
+            'first_name' => 'Charlie',
+            'last_name' => 'Other',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('cv.history'));
+
+        $response->assertOk();
+        $response->assertSee('Alice Writer', false);
+        $response->assertSee('Bob Designer', false);
+        $response->assertDontSee('Charlie Other');
+    }
+
+    public function test_user_can_update_cv(): void
+    {
+        $user = User::factory()->create();
+        $cv = Cv::factory()->for($user)->create([
+            'first_name' => 'Initial',
+            'template' => 'classic',
+        ]);
+
+        $payload = [
+            'first_name' => 'Updated',
+            'last_name' => 'Candidate',
+            'email' => 'updated@example.com',
+            'phone' => '123456789',
+            'birthday' => '1990-01-01',
+            'country' => 'France',
+            'city' => 'Paris',
+            'template' => 'modern',
+            'education' => [
+                [
+                    'institution' => 'Updated University',
+                    'degree' => 'MBA',
+                    'field' => 'Management',
+                    'country' => 'France',
+                    'city' => 'Paris',
+                    'start_year' => '2012',
+                    'end_year' => '2014',
+                ],
+            ],
+            'experience' => [
+                [
+                    'position' => 'Lead',
+                    'company' => 'Acme Corp',
+                    'country' => 'France',
+                    'city' => 'Paris',
+                    'from' => '2015-01',
+                    'to' => '2019-01',
+                    'currently' => false,
+                    'achievements' => 'Improved processes.',
+                ],
+            ],
+            'hobbies' => ['Cycling', 'Painting'],
+        ];
+
+        $response = $this->actingAs($user)->put(route('cv.update', $cv), $payload);
+
+        $response->assertRedirect(route('cv.preview'));
+        $response->assertSessionHas('status', __('Your CV has been updated.'));
+
+        $cv->refresh();
+
+        $this->assertEquals('Updated', $cv->first_name);
+        $this->assertEquals('modern', $cv->template);
+        $this->assertEquals(['Cycling', 'Painting'], $cv->hobbies);
+        $this->assertEquals('updated@example.com', $cv->email);
+        $this->assertSame('Paris', $cv->city);
+
+        $this->assertEquals('Updated', session('cv_data.first_name'));
+    }
+
+    public function test_user_can_delete_cv(): void
+    {
+        $user = User::factory()->create();
+        $cv = Cv::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)
+            ->withSession(['cv_data' => ['id' => $cv->id]])
+            ->delete(route('cv.destroy', $cv));
+
+        $response->assertRedirect(route('cv.history'));
+        $response->assertSessionHas('status', __('The CV has been deleted.'));
+        $response->assertSessionMissing('cv_data');
+
+        $this->assertDatabaseMissing('cvs', ['id' => $cv->id]);
+    }
+
+    public function test_user_cannot_manage_another_users_cv(): void
+    {
+        $user = User::factory()->create();
+        $otherCv = Cv::factory()->for(User::factory())->create();
+
+        $this->actingAs($user)
+            ->get(route('cv.edit', $otherCv))
+            ->assertForbidden();
+
+        $this->actingAs($user)
+            ->put(route('cv.update', $otherCv), [])
+            ->assertForbidden();
+
+        $this->actingAs($user)
+            ->delete(route('cv.destroy', $otherCv))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- remove the Instagram OAuth flow so social auth uses Google only and refresh the provider button styling
- add CV history, edit, update, and delete routes with controller helpers, keeping the create form blank by default
- introduce a history page, navigation/dashboard links, a CV factory, and feature coverage for the new workflow

## Testing
- not run (composer install requires a GitHub token in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d39b4535708332bf98210a3717b8dc