### PR TITLE
Fix CV history view Str import to prevent syntax error

### DIFF
--- a/resources/views/cv/history.blade.php
+++ b/resources/views/cv/history.blade.php
@@ -1,7 +1,5 @@
 <x-app-layout>
     @php
-        use Illuminate\Support\Str;
-
         $entries = collect($entries ?? []);
         $totalCount = $entries->count();
         $subtitle = $totalCount > 0
@@ -51,7 +49,7 @@
                     @php
                         /** @var \App\Models\Cv $cv */
                         $cv = $entry['cv'];
-                        $templateName = Str::of($entry['template'] ?? 'classic')->headline();
+                        $templateName = \Illuminate\Support\Str::of($entry['template'] ?? 'classic')->headline();
                         $updatedHuman = optional($entry['updated_at'])->diffForHumans() ?? __('just now');
                         $createdDate = optional($entry['created_at'])->toFormattedDateString();
                         $educationLabel = trans_choice(':count education entry|:count education entries', $entry['education_count'], ['count' => $entry['education_count']]);


### PR DESCRIPTION
## Summary
- remove the inline `use` statement from the CV history blade template that caused the syntax error
- reference the `Str` helper with its fully qualified namespace when building template labels

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a17483c883329295d02457789099