### PR TITLE
Revamp dashboard styling and template previews

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -16,7 +16,7 @@
     }
 
     .createit-auth__grid {
-        @apply relative grid min-h-screen gap-12 md:grid-cols-[1.05fr,1fr];
+        @apply relative mx-auto grid min-h-screen w-full max-w-6xl items-center justify-center gap-12 px-6 py-16 md:grid-cols-[1fr,1fr];
     }
 
     .createit-auth__info {
@@ -265,5 +265,154 @@
 
     .createit-footer {
         @apply bg-white py-6 text-center text-sm text-slate-500;
+    }
+
+    .createit-dashboard {
+        @apply space-y-12;
+    }
+
+    .createit-dashboard__hero {
+        @apply relative overflow-hidden rounded-[32px] bg-gradient-to-br from-slate-950 via-slate-900 to-black px-10 py-14 text-white shadow-2xl;
+    }
+
+    .createit-dashboard__hero::after {
+        content: '';
+        position: absolute;
+        pointer-events: none;
+        bottom: -6rem;
+        right: -5rem;
+        height: 16rem;
+        width: 16rem;
+        border-radius: 9999px;
+        background-color: rgba(59, 130, 246, 0.4);
+        filter: blur(48px);
+    }
+
+    .createit-dashboard__badge {
+        @apply inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/70;
+    }
+
+    .createit-dashboard__title {
+        @apply mt-6 text-4xl font-semibold tracking-tight;
+    }
+
+    .createit-dashboard__subtitle {
+        @apply mt-4 max-w-2xl text-base text-white/80;
+    }
+
+    .createit-dashboard__actions {
+        @apply mt-8 flex flex-wrap gap-4;
+    }
+
+    .createit-dashboard__action {
+        @apply inline-flex items-center justify-center gap-2 rounded-full bg-white/90 px-5 py-3 text-sm font-semibold text-slate-900 transition hover:-translate-y-0.5 hover:bg-white;
+    }
+
+    .createit-dashboard__grid {
+        @apply grid gap-6 lg:grid-cols-12;
+    }
+
+    .createit-dashboard__card {
+        @apply relative overflow-hidden rounded-[28px] border border-slate-200 bg-white/90 p-8 shadow-lg shadow-slate-200/60 backdrop-blur transition hover:-translate-y-1 hover:shadow-2xl;
+    }
+
+    .createit-dashboard__card-badge {
+        @apply inline-flex items-center gap-2 rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white;
+    }
+
+    .createit-dashboard__card-title {
+        @apply mt-5 text-2xl font-semibold text-slate-900;
+    }
+
+    .createit-dashboard__card-text {
+        @apply mt-3 text-sm text-slate-500;
+    }
+
+    .createit-dashboard__card-link {
+        @apply mt-8 inline-flex items-center gap-2 text-sm font-semibold text-slate-900 transition hover:text-blue-600;
+    }
+
+    .createit-dashboard__stats {
+        @apply grid gap-4 sm:grid-cols-2;
+    }
+
+    .createit-dashboard__stat {
+        @apply rounded-3xl border border-slate-100 bg-slate-50/70 p-6 shadow-inner shadow-slate-200/60;
+    }
+
+    .createit-dashboard__stat-label {
+        @apply text-xs uppercase tracking-[0.35em] text-slate-400;
+    }
+
+    .createit-dashboard__stat-value {
+        @apply mt-4 text-3xl font-semibold text-slate-900;
+    }
+
+    .createit-dashboard__stat-meta {
+        @apply mt-1 text-xs text-slate-500;
+    }
+
+    .createit-template-card {
+        @apply relative flex h-full flex-col overflow-hidden rounded-[28px] border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-2xl;
+    }
+
+    .createit-template-card__preview {
+        @apply relative h-48 bg-gradient-to-br;
+    }
+
+    .createit-template-card__badge {
+        @apply absolute top-4 right-4 inline-flex items-center gap-1 rounded-full bg-white/80 px-3 py-1 text-xs font-medium text-slate-600 shadow;
+    }
+
+    .createit-template-card__body {
+        @apply flex flex-1 flex-col gap-4 p-6;
+    }
+
+    .createit-template-card__title {
+        @apply text-xl font-semibold text-slate-900;
+    }
+
+    .createit-template-card__description {
+        @apply mt-2 text-sm text-slate-500;
+    }
+
+    .createit-template-card__actions {
+        @apply mt-auto flex flex-wrap items-center justify-between gap-3;
+    }
+
+    .createit-template-card__action {
+        @apply inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition group-hover:bg-black;
+    }
+
+    .createit-template-card__preview-button {
+        @apply inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-blue-500 hover:text-blue-600;
+    }
+
+    .createit-modal {
+        @apply m-0 w-full max-w-5xl overflow-hidden rounded-[32px] border border-slate-200 bg-white/95 p-0 shadow-2xl backdrop:bg-slate-900/70;
+    }
+
+    .createit-modal__header {
+        @apply flex items-center justify-between border-b border-slate-200 bg-white/80 px-6 py-4;
+    }
+
+    .createit-modal__title {
+        @apply text-lg font-semibold text-slate-900;
+    }
+
+    .createit-modal__body {
+        @apply bg-slate-100/60 p-6;
+    }
+
+    .createit-modal__iframe-wrapper {
+        @apply overflow-hidden rounded-2xl border border-slate-200 shadow-lg;
+    }
+
+    .createit-modal__iframe {
+        @apply h-[28rem] w-full;
+    }
+
+    .createit-modal__close {
+        @apply inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-blue-500 hover:text-blue-600;
     }
 }

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -47,6 +47,54 @@
                 'preview' => 'from-indigo-300 via-purple-300 to-slate-100',
             ],
         ];
+
+        $sampleCv = [
+            'first_name' => 'Jordan',
+            'last_name' => 'Rivera',
+            'headline' => 'Product Designer',
+            'email' => 'jordan.rivera@example.com',
+            'phone' => '+1 (555) 123-4567',
+            'city' => 'Toronto',
+            'country' => 'Canada',
+            'summary' => 'Designer blending research, motion, and storytelling to craft delightful digital experiences.',
+            'work_experience' => [
+                [
+                    'position' => 'Senior Product Designer',
+                    'company' => 'Northwind Studio',
+                    'city' => 'Toronto',
+                    'country' => 'Canada',
+                    'from' => '2021-02',
+                    'currently' => true,
+                    'achievements' => 'Led cross-functional sprints and launched a design system that lifted activation by 28%.',
+                ],
+                [
+                    'position' => 'Product Designer',
+                    'company' => 'Aurora Labs',
+                    'city' => 'Vancouver',
+                    'country' => 'Canada',
+                    'from' => '2018-05',
+                    'to' => '2021-01',
+                    'achievements' => 'Prototyped immersive flows that increased retention across mobile and web surfaces.',
+                ],
+            ],
+            'education' => [
+                [
+                    'degree' => 'B.A. Interaction Design',
+                    'institution' => 'University of British Columbia',
+                    'city' => 'Vancouver',
+                    'country' => 'Canada',
+                    'start_year' => '2014',
+                    'end_year' => '2018',
+                    'field' => 'Design & Technology',
+                ],
+            ],
+            'skills' => ['Design Systems', 'User Research', 'Prototyping', 'Motion'],
+            'languages' => [
+                ['name' => 'English', 'level' => 'native'],
+                ['name' => 'French', 'level' => 'advanced'],
+            ],
+            'hobbies' => ['Gallery hopping', 'Cycling', 'Synth music'],
+        ];
     @endphp
 
     <div class="space-y-10">
@@ -67,9 +115,13 @@
                         'description' => 'Beautiful layout ready for your details.',
                         'preview' => 'from-slate-200 via-white to-slate-100',
                     ];
+                    $previewId = 'template-preview-' . $template;
+                    $previewSource = view('templates.' . $template, [
+                        'cv' => (object) array_merge($sampleCv, ['template' => $template]),
+                    ])->render();
                 @endphp
-                <div class="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-2xl">
-                    <div class="relative h-48 bg-gradient-to-br {{ $meta['preview'] }}">
+                <div class="group createit-template-card">
+                    <div class="createit-template-card__preview bg-gradient-to-br {{ $meta['preview'] }}">
                         <div class="absolute inset-0 flex items-center justify-center">
                             <div class="w-40 rounded-2xl bg-white/80 p-4 shadow-xl shadow-slate-300/50">
                                 <div class="h-2 w-24 rounded-full bg-slate-200"></div>
@@ -80,26 +132,78 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="absolute top-4 right-4 flex items-center gap-1 rounded-full bg-white/70 px-3 py-1 text-xs font-medium text-slate-600 shadow-sm">
+                        <div class="createit-template-card__badge">
                             <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
-                            Preview ready
+                            {{ __('Preview ready') }}
                         </div>
                     </div>
-                    <div class="flex flex-1 flex-col gap-4 p-6">
+                    <div class="createit-template-card__body">
                         <div>
-                            <h2 class="text-xl font-semibold text-slate-900">{{ $meta['title'] }}</h2>
-                            <p class="mt-2 text-sm text-slate-500">{{ $meta['description'] }}</p>
+                            <h2 class="createit-template-card__title">{{ $meta['title'] }}</h2>
+                            <p class="createit-template-card__description">{{ $meta['description'] }}</p>
                         </div>
-                        <div class="mt-auto flex flex-wrap items-center justify-between gap-3">
-                            <a href="{{ route('cv.create', ['template' => $template]) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition group-hover:bg-black">
-                                Use template
+                        <div class="createit-template-card__actions">
+                            <a href="{{ route('cv.create', ['template' => $template]) }}" class="createit-template-card__action">
+                                {{ __('Use template') }}
                                 <span aria-hidden="true">&rarr;</span>
                             </a>
-                            <span class="text-xs uppercase tracking-[0.2em] text-slate-400">{{ strtoupper($template) }}</span>
+                            <button type="button" class="createit-template-card__preview-button" data-preview-trigger="{{ $previewId }}">
+                                {{ __('Preview') }}
+                            </button>
                         </div>
                     </div>
                 </div>
+
+                <dialog id="{{ $previewId }}" class="createit-modal" aria-label="{{ $meta['title'] }} template preview">
+                    <div class="createit-modal__header">
+                        <h3 class="createit-modal__title">{{ $meta['title'] }} {{ __('template preview') }}</h3>
+                        <button type="button" class="createit-modal__close" data-preview-close>{{ __('Close') }}</button>
+                    </div>
+                    <div class="createit-modal__body">
+                        <div class="createit-modal__iframe-wrapper">
+                            <iframe class="createit-modal__iframe" srcdoc="{{ e($previewSource) }}" title="{{ $meta['title'] }} template preview"></iframe>
+                        </div>
+                    </div>
+                </dialog>
             @endforeach
         </div>
     </div>
 </x-app-layout>
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const dialogs = new Map();
+
+            document.querySelectorAll('.createit-modal').forEach((dialog) => {
+                dialogs.set(dialog.id, dialog);
+                dialog.addEventListener('click', (event) => {
+                    const rect = dialog.getBoundingClientRect();
+                    const clickedOutside = event.clientX < rect.left || event.clientX > rect.right || event.clientY < rect.top || event.clientY > rect.bottom;
+                    if (clickedOutside) {
+                        dialog.close();
+                    }
+                });
+            });
+
+            document.querySelectorAll('[data-preview-trigger]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const targetId = button.getAttribute('data-preview-trigger');
+                    const dialog = dialogs.get(targetId);
+                    if (dialog && typeof dialog.showModal === 'function') {
+                        dialog.showModal();
+                    }
+                });
+            });
+
+            document.querySelectorAll('[data-preview-close]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const dialog = button.closest('.createit-modal');
+                    if (dialog && typeof dialog.close === 'function') {
+                        dialog.close();
+                    }
+                });
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,15 +1,144 @@
 <x-app-layout>
-    
+    @php
+        $user = auth()->user();
+        $cvCount = $user ? $user->cvs()->count() : 0;
+        $recentCv = $user ? $user->cvs()->latest('updated_at')->first() : null;
+        $templateCount = $user ? $user->cvs()->select('template')->distinct()->count() : 0;
 
-    <div class="bg-white shadow rounded-lg p-8 text-center">
-        <h2 class="text-3xl font-bold mb-6">Dashboard</h2>
-        <p class="text-gray-600 mb-8">Manage your CVs and profile settings.</p>
+        $lastUpdatedLabel = $recentCv && $recentCv->updated_at ? $recentCv->updated_at->diffForHumans() : null;
+        $recentTemplate = $recentCv && $recentCv->template ? ucfirst($recentCv->template) : null;
+        $recentTitle = null;
 
-        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
-            <a href="{{ route('cv.create') }}" class="block bg-gradient-to-r from-blue-500 to-indigo-600 text-white py-4 rounded-lg shadow hover:opacity-90">Create CV</a>
-            <a href="{{ route('cv.history') }}" class="block bg-gradient-to-r from-slate-600 to-slate-800 text-white py-4 rounded-lg shadow hover:opacity-90">CV History</a>
-            <a href="{{ route('cv.guide') }}" class="block bg-gradient-to-r from-gray-500 to-gray-700 text-white py-4 rounded-lg shadow hover:opacity-90">CV Guide</a>
-            <a href="{{ route('cv.templates') }}" class="block bg-gradient-to-r from-green-500 to-emerald-600 text-white py-4 rounded-lg shadow hover:opacity-90">CV Templates</a>
+        if ($recentCv) {
+            $recentTitle = collect([
+                $recentCv->first_name ?? null,
+                $recentCv->last_name ?? null,
+            ])
+                ->filter(fn ($value) => is_string($value) && trim($value) !== '')
+                ->map(fn ($value) => trim($value))
+                ->implode(' ');
+
+            if ($recentTitle === '') {
+                $recentTitle = __('Untitled CV');
+            }
+        }
+
+        $userName = $user ? ($user->name ?: ($user->first_name ?? null)) : null;
+        $userGreeting = $userName ? __('Welcome back, :name!', ['name' => $userName]) : __('Welcome back!');
+    @endphp
+
+    <div class="createit-dashboard">
+        <section class="createit-dashboard__hero">
+            <div class="relative z-10 max-w-3xl">
+                <span class="createit-dashboard__badge">
+                    <span class="createit-dot"></span>
+                    {{ __('Your creative workspace') }}
+                </span>
+                <h1 class="createit-dashboard__title">{{ $userGreeting }}</h1>
+                <p class="createit-dashboard__subtitle">
+                    {{ __('Keep iterating on your resumes, explore bold templates, and export polished PDFs whenever you are ready.') }}
+                </p>
+                <div class="createit-dashboard__actions">
+                    <a href="{{ route('cv.create') }}" class="createit-dashboard__action">
+                        {{ __('Open builder') }}
+                        <span aria-hidden="true">→</span>
+                    </a>
+                    <a href="{{ route('cv.templates') }}" class="createit-navbar__primary">
+                        {{ __('Browse templates') }}
+                    </a>
+                    <a href="{{ route('cv.history') }}" class="createit-navbar__link text-white/80 hover:text-white">
+                        {{ __('View history') }}
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        <div class="createit-dashboard__grid">
+            <div class="lg:col-span-7 space-y-6">
+                <article class="createit-dashboard__card">
+                    <div class="absolute -top-20 -right-10 h-40 w-40 rounded-full bg-blue-500/10 blur-3xl"></div>
+                    <span class="createit-dashboard__card-badge">{{ __('Builder') }}</span>
+                    <h2 class="createit-dashboard__card-title">{{ __('Craft a new CV') }}</h2>
+                    <p class="createit-dashboard__card-text">
+                        {{ __('Follow the guided steps, auto-fill locations, and experiment with live previews to shape your next standout CV.') }}
+                    </p>
+                    <a href="{{ route('cv.create') }}" class="createit-dashboard__card-link">
+                        {{ __('Start building') }}
+                        <span aria-hidden="true">→</span>
+                    </a>
+                </article>
+
+                <article class="createit-dashboard__card">
+                    <div class="absolute -bottom-24 -left-16 h-44 w-44 rounded-full bg-emerald-400/10 blur-3xl"></div>
+                    <span class="createit-dashboard__card-badge">{{ __('Resources') }}</span>
+                    <h2 class="createit-dashboard__card-title">{{ __('Learn and iterate') }}</h2>
+                    <p class="createit-dashboard__card-text">
+                        {{ __('Access writing prompts, structure ideas with our guide, and keep previous drafts within reach while you refine your story.') }}
+                    </p>
+                    <div class="mt-8 flex flex-wrap gap-3">
+                        <a href="{{ route('cv.guide') }}" class="createit-template-card__preview-button">
+                            {{ __('Open CV guide') }}
+                        </a>
+                        <a href="{{ route('cv.history') }}" class="createit-template-card__preview-button">
+                            {{ __('View saved CVs') }}
+                        </a>
+                    </div>
+                </article>
+            </div>
+
+            <aside class="lg:col-span-5 space-y-6">
+                <section class="createit-dashboard__card">
+                    <span class="createit-dashboard__card-badge">{{ __('Insights') }}</span>
+                    <h2 class="createit-dashboard__card-title">{{ __('Your progress') }}</h2>
+                    <p class="createit-dashboard__card-text">
+                        {{ __('Track how many resumes you have crafted and the styles you gravitate toward.') }}
+                    </p>
+                    <div class="createit-dashboard__stats mt-6">
+                        <div class="createit-dashboard__stat">
+                            <p class="createit-dashboard__stat-label">{{ __('CVs created') }}</p>
+                            <p class="createit-dashboard__stat-value">{{ $cvCount }}</p>
+                            <p class="createit-dashboard__stat-meta">{{ __('All time') }}</p>
+                        </div>
+                        <div class="createit-dashboard__stat">
+                            <p class="createit-dashboard__stat-label">{{ __('Templates tried') }}</p>
+                            <p class="createit-dashboard__stat-value">{{ $templateCount }}</p>
+                            <p class="createit-dashboard__stat-meta">{{ __('Different looks explored') }}</p>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="createit-dashboard__card">
+                    <span class="createit-dashboard__card-badge">{{ __('Latest draft') }}</span>
+                    <h2 class="createit-dashboard__card-title">
+                        {{ $recentTitle ?? __('No CV saved yet') }}
+                    </h2>
+                    @if ($recentTemplate || $lastUpdatedLabel)
+                        <ul class="mt-4 space-y-2 text-sm text-slate-500">
+                            @if ($recentTemplate)
+                                <li>
+                                    <span class="font-medium text-slate-700">{{ __('Template') }}:</span>
+                                    {{ $recentTemplate }}
+                                </li>
+                            @endif
+                            @if ($lastUpdatedLabel)
+                                <li>
+                                    <span class="font-medium text-slate-700">{{ __('Updated') }}:</span>
+                                    {{ $lastUpdatedLabel }}
+                                </li>
+                            @endif
+                        </ul>
+                    @else
+                        <p class="createit-dashboard__card-text">
+                            {{ __('Save your first CV to see quick insights here.') }}
+                        </p>
+                    @endif
+
+                    <a href="{{ route('cv.templates') }}" class="createit-dashboard__card-link">
+                        {{ __('Explore templates') }}
+                        <span aria-hidden="true">→</span>
+                    </a>
+                </section>
+            </aside>
         </div>
     </div>
 </x-app-layout>

--- a/resources/views/templates/classic.blade.php
+++ b/resources/views/templates/classic.blade.php
@@ -2,52 +2,275 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>{{ $cv->name ?? 'My CV' }}</title>
+    <title>Classic · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Arial, sans-serif; margin: 40px; color: #333; }
-        h1, h2 { margin-bottom: 0; }
-        .section { margin-bottom: 20px; }
-        .header { border-bottom: 2px solid #000; padding-bottom: 10px; margin-bottom: 20px; }
-        .job { margin-bottom: 10px; }
-        .small { font-size: 14px; color: #666; }
+        :root {
+            --slate-900: #0f172a;
+            --slate-700: #334155;
+            --slate-500: #64748b;
+            --slate-200: #e2e8f0;
+            --slate-100: #f1f5f9;
+            --accent: #1f2937;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Georgia", "Times New Roman", serif;
+            color: var(--slate-900);
+            background: var(--slate-100);
+            padding: 40px;
+            line-height: 1.6;
+            font-size: 14px;
+        }
+
+        .page {
+            background: #fff;
+            border: 1px solid var(--slate-200);
+            border-radius: 18px;
+            overflow: hidden;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.08);
+        }
+
+        header {
+            padding: 40px;
+            border-bottom: 1px solid var(--slate-200);
+            display: grid;
+            grid-template-columns: 1fr auto;
+            gap: 24px;
+            align-items: center;
+            background: linear-gradient(135deg, rgba(15, 23, 42, 0.04), rgba(148, 163, 184, 0.12));
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 32px;
+            letter-spacing: 0.02em;
+        }
+
+        header p {
+            margin: 6px 0 0;
+            font-size: 15px;
+            color: var(--slate-500);
+        }
+
+        .contact {
+            text-align: right;
+            font-size: 12px;
+            color: var(--slate-500);
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 280px 1fr;
+            gap: 32px;
+            padding: 40px;
+        }
+
+        .sidebar {
+            border-right: 1px solid var(--slate-200);
+            padding-right: 32px;
+        }
+
+        h2 {
+            text-transform: uppercase;
+            letter-spacing: 0.3em;
+            font-size: 12px;
+            color: var(--slate-500);
+            margin: 0 0 16px;
+        }
+
+        h3 {
+            margin: 0;
+            font-size: 16px;
+            color: var(--accent);
+        }
+
+        .section {
+            margin-bottom: 32px;
+        }
+
+        .section:last-child {
+            margin-bottom: 0;
+        }
+
+        .item {
+            margin-bottom: 20px;
+        }
+
+        .item:last-child {
+            margin-bottom: 0;
+        }
+
+        .meta {
+            color: var(--slate-500);
+            font-size: 12px;
+            margin-top: 6px;
+        }
+
+        ul {
+            padding-left: 18px;
+            margin: 0;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
+
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.32em;
+            color: var(--slate-500);
+        }
+
+        .divider {
+            height: 1px;
+            background: linear-gradient(to right, transparent, rgba(148, 163, 184, 0.6), transparent);
+            margin: 24px 0;
+        }
+
+        .summary {
+            background: rgba(15, 23, 42, 0.04);
+            padding: 18px;
+            border-radius: 12px;
+            font-size: 13px;
+            color: var(--slate-700);
+        }
     </style>
 </head>
 <body>
-    <div class="header">
-        <h1>{{ $cv->name }}</h1>
-        <p class="small">{{ $cv->email }} | {{ $cv->phone }} | {{ $cv->birthday }}</p>
-    </div>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <div class="section">
-        <h2>Experience</h2>
-        @foreach($cv->experiences as $exp)
-            <div class="job">
-                <strong>{{ $exp->position }}</strong> – {{ $exp->company }}
-                <div class="small">{{ $exp->city }}, {{ $exp->country }}</div>
-                <div class="small">
-                    {{ $exp->start_date }} – {{ $exp->currently ? 'Present' : $exp->end_date }}
-                </div>
-                <p>{{ $exp->description }}</p>
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="page">
+        <header>
+            <div>
+                <span class="badge">{{ __('Classic Resume') }}</span>
+                <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+                @if ($data['headline'])
+                    <p>{{ $data['headline'] }}</p>
+                @endif
             </div>
-        @endforeach
-    </div>
-
-    @if(!empty($cv->achievements))
-        <div class="section">
-            <h2>Achievements</h2>
-            <ul>
-                @foreach($cv->achievements as $a)
-                    <li>{{ $a }}</li>
+            <div class="contact">
+                @foreach ($data['contacts'] as $contact)
+                    <div>{{ $contact }}</div>
                 @endforeach
-            </ul>
-        </div>
-    @endif
+            </div>
+        </header>
 
-    @if(!empty($cv->about))
-        <div class="section">
-            <h2>About Me</h2>
-            <p>{{ $cv->about }}</p>
+        <div class="layout">
+            <aside class="sidebar">
+                @if ($data['summary'])
+                    <div class="section">
+                        <h2>{{ __('Profile') }}</h2>
+                        <div class="summary">{{ $data['summary'] }}</div>
+                    </div>
+                @endif
+
+                @if (!empty($data['skills']))
+                    <div class="section">
+                        <h2>{{ __('Skills') }}</h2>
+                        <ul>
+                            @foreach ($data['skills'] as $skill)
+                                <li>{{ $skill }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <div class="section">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    {{ $language['name'] }}
+                                    @if (!empty($language['level']))
+                                        <span class="meta">&mdash; {{ ucfirst($language['level']) }}</span>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <div class="section">
+                        <h2>{{ __('Interests') }}</h2>
+                        <ul>
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </aside>
+
+            <main>
+                @if (!empty($data['experiences']))
+                    <div class="section">
+                        <h2>{{ __('Experience') }}</h2>
+                        @foreach ($data['experiences'] as $experience)
+                            <div class="item">
+                                @if ($experience['role'])
+                                    <h3>{{ $experience['role'] }}</h3>
+                                @endif
+                                <div class="meta">
+                                    {{ $experience['company'] }}
+                                    @if ($experience['company'] && $experience['location'])
+                                        &middot;
+                                    @endif
+                                    {{ $experience['location'] }}
+                                </div>
+                                @if ($experience['period'])
+                                    <div class="meta">{{ $experience['period'] }}</div>
+                                @endif
+                                @if ($experience['summary'])
+                                    <p class="meta" style="margin-top: 12px; color: var(--slate-700); font-size: 13px;">{{ $experience['summary'] }}</p>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+
+                @if (!empty($data['education']))
+                    <div class="divider"></div>
+                    <div class="section">
+                        <h2>{{ __('Education') }}</h2>
+                        @foreach ($data['education'] as $education)
+                            <div class="item">
+                                @if ($education['degree'])
+                                    <h3>{{ $education['degree'] }}</h3>
+                                @endif
+                                <div class="meta">
+                                    {{ $education['institution'] }}
+                                    @if ($education['institution'] && $education['location'])
+                                        &middot;
+                                    @endif
+                                    {{ $education['location'] }}
+                                </div>
+                                @if ($education['period'])
+                                    <div class="meta">{{ $education['period'] }}</div>
+                                @endif
+                                @if ($education['field'])
+                                    <div class="meta" style="margin-top: 8px; color: var(--slate-700);">{{ $education['field'] }}</div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </main>
         </div>
-    @endif
+    </div>
 </body>
 </html>

--- a/resources/views/templates/corporate.blade.php
+++ b/resources/views/templates/corporate.blade.php
@@ -1,25 +1,273 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Corporate</title>
+    <meta charset="UTF-8">
+    <title>Corporate · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Arial, sans-serif; color: #111; background: #F3F4F6; }
-        h1 { background: #111827; color: white; padding: 8px; }
-        h2 { color: #374151; }
-        .section { border: 1px solid #D1D5DB; padding: 10px; margin: 15px 0; }
+        :root {
+            --navy: #0f172a;
+            --steel: #1e293b;
+            --ash: #64748b;
+            --cloud: #e2e8f0;
+            --snow: #f8fafc;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Source Sans Pro", Arial, sans-serif;
+            background: var(--snow);
+            color: var(--navy);
+            font-size: 13px;
+            line-height: 1.65;
+            padding: 32px;
+        }
+
+        .layout {
+            display: grid;
+            grid-template-columns: 260px 1fr;
+            border-radius: 24px;
+            overflow: hidden;
+            box-shadow: 0 20px 60px rgba(15, 23, 42, 0.15);
+            border: 1px solid rgba(100, 116, 139, 0.18);
+        }
+
+        aside {
+            background: linear-gradient(180deg, var(--steel), var(--navy));
+            color: #fff;
+            padding: 40px 32px;
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        aside h2 {
+            margin: 0 0 14px;
+            font-size: 12px;
+            letter-spacing: 0.3em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .identity h1 {
+            margin: 0;
+            font-size: 22px;
+            letter-spacing: 0.04em;
+        }
+
+        .identity p {
+            margin: 8px 0 0;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .contact {
+            display: grid;
+            gap: 8px;
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .badge-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .badge {
+            background: rgba(15, 23, 42, 0.35);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+        }
+
+        main {
+            background: #fff;
+            padding: 48px;
+            display: flex;
+            flex-direction: column;
+            gap: 40px;
+        }
+
+        main h2 {
+            margin: 0 0 18px;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.35em;
+            color: var(--ash);
+        }
+
+        .entry {
+            margin-bottom: 24px;
+            border-bottom: 1px solid var(--cloud);
+            padding-bottom: 18px;
+        }
+
+        .entry:last-child {
+            margin-bottom: 0;
+            border-bottom: none;
+            padding-bottom: 0;
+        }
+
+        .entry h3 {
+            margin: 0;
+            font-size: 18px;
+            letter-spacing: 0.02em;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 12px;
+            color: var(--ash);
+        }
+
+        .entry p {
+            margin-top: 12px;
+            color: var(--ash);
+            font-size: 13px;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>Email: {{ $data['email'] ?? '' }} | Phone: {{ $data['phone'] ?? '' }} | Birthday: {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            <b>{{ $exp['title'] ?? '' }}</b> - {{ $exp['company'] ?? '' }}<br>
-            {{ $exp['start'] ?? '' }} → {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }}
-        </div>
-    @endforeach
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="layout">
+        <aside>
+            <div class="identity">
+                <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+                @if ($data['headline'])
+                    <p>{{ $data['headline'] }}</p>
+                @endif
+            </div>
+
+            @if (!empty($data['contacts']))
+                <div>
+                    <h2>{{ __('Contact') }}</h2>
+                    <div class="contact">
+                        @foreach ($data['contacts'] as $contact)
+                            <span>{{ $contact }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            @if ($data['summary'])
+                <div>
+                    <h2>{{ __('Summary') }}</h2>
+                    <p style="font-size: 13px; line-height: 1.7; color: rgba(255, 255, 255, 0.8);">{{ $data['summary'] }}</p>
+                </div>
+            @endif
+
+            @if (!empty($data['skills']))
+                <div>
+                    <h2>{{ __('Core Skills') }}</h2>
+                    <div class="badge-list">
+                        @foreach ($data['skills'] as $skill)
+                            <span class="badge">{{ $skill }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            @if (!empty($data['languages']))
+                <div>
+                    <h2>{{ __('Languages') }}</h2>
+                    <ul>
+                        @foreach ($data['languages'] as $language)
+                            <li>
+                                {{ $language['name'] }}
+                                @if (!empty($language['level']))
+                                    &mdash; {{ ucfirst($language['level']) }}
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
+        </aside>
+
+        <main>
+            @if (!empty($data['experiences']))
+                <section>
+                    <h2>{{ __('Experience') }}</h2>
+                    @foreach ($data['experiences'] as $experience)
+                        <article class="entry">
+                            @if ($experience['role'])
+                                <h3>{{ $experience['role'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $experience['company'] }}
+                                @if ($experience['company'] && $experience['location'])
+                                    &middot;
+                                @endif
+                                {{ $experience['location'] }}
+                                @if ($experience['period'])
+                                    &middot;
+                                    {{ $experience['period'] }}
+                                @endif
+                            </div>
+                            @if ($experience['summary'])
+                                <p>{{ $experience['summary'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                </section>
+            @endif
+
+            @if (!empty($data['education']))
+                <section>
+                    <h2>{{ __('Education') }}</h2>
+                    @foreach ($data['education'] as $education)
+                        <article class="entry">
+                            @if ($education['institution'])
+                                <h3>{{ $education['institution'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $education['degree'] }}
+                                @if ($education['degree'] && $education['location'])
+                                    &middot;
+                                @endif
+                                {{ $education['location'] }}
+                                @if ($education['period'])
+                                    &middot;
+                                    {{ $education['period'] }}
+                                @endif
+                            </div>
+                            @if ($education['field'])
+                                <p>{{ $education['field'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                </section>
+            @endif
+
+            @if (!empty($data['hobbies']))
+                <section>
+                    <h2>{{ __('Interests') }}</h2>
+                    <ul>
+                        @foreach ($data['hobbies'] as $hobby)
+                            <li>{{ $hobby }}</li>
+                        @endforeach
+                    </ul>
+                </section>
+            @endif
+        </main>
+    </div>
 </body>
 </html>

--- a/resources/views/templates/creative.blade.php
+++ b/resources/views/templates/creative.blade.php
@@ -1,26 +1,321 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Creative</title>
+    <meta charset="UTF-8">
+    <title>Creative · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: "Comic Sans MS", cursive, sans-serif; background: #FFFBEB; color: #78350F; }
-        h1 { color: #D97706; text-align: center; }
-        .section { background: #FEF3C7; padding: 15px; border-radius: 10px; margin-bottom: 20px; }
+        :root {
+            --pink: #ec4899;
+            --purple: #8b5cf6;
+            --sky: #38bdf8;
+            --ink: #0f172a;
+            --slate-600: #475569;
+            --slate-400: #94a3b8;
+            --paper: #fdf4ff;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Poppins", "Helvetica Neue", Arial, sans-serif;
+            background: linear-gradient(120deg, rgba(236, 72, 153, 0.1), rgba(59, 130, 246, 0.08));
+            color: var(--ink);
+            font-size: 14px;
+            line-height: 1.6;
+            padding: 36px;
+        }
+
+        .canvas {
+            background: #fff;
+            border-radius: 36px;
+            overflow: hidden;
+            box-shadow: 0 24px 70px rgba(15, 23, 42, 0.14);
+            border: 1px solid rgba(148, 163, 184, 0.4);
+        }
+
+        header {
+            background: linear-gradient(135deg, rgba(236, 72, 153, 0.92), rgba(59, 130, 246, 0.92));
+            color: #fff;
+            padding: 48px 56px 56px;
+            position: relative;
+        }
+
+        header::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.35), transparent 45%);
+            pointer-events: none;
+        }
+
+        .heading {
+            position: relative;
+            z-index: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .eyebrow {
+            font-size: 12px;
+            letter-spacing: 0.4em;
+            text-transform: uppercase;
+            color: rgba(255, 255, 255, 0.7);
+            margin: 0;
+        }
+
+        .name {
+            margin: 0;
+            font-size: 34px;
+            font-weight: 700;
+            letter-spacing: 0.03em;
+        }
+
+        .headline {
+            margin: 0;
+            font-size: 16px;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .contact {
+            margin-top: 18px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .body {
+            display: grid;
+            grid-template-columns: 320px 1fr;
+            gap: 40px;
+            padding: 48px 56px 56px;
+        }
+
+        .sidebar {
+            display: flex;
+            flex-direction: column;
+            gap: 28px;
+        }
+
+        .card {
+            background: var(--paper);
+            border-radius: 24px;
+            padding: 24px;
+            border: 1px solid rgba(236, 72, 153, 0.15);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+        }
+
+        .card h2,
+        .section h2 {
+            margin: 0 0 16px;
+            font-size: 13px;
+            letter-spacing: 0.35em;
+            text-transform: uppercase;
+            color: var(--slate-400);
+        }
+
+        .card p {
+            margin: 0;
+            font-size: 13px;
+            color: var(--slate-600);
+        }
+
+        .badge-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .badge {
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+            font-weight: 500;
+            background: rgba(236, 72, 153, 0.12);
+            color: var(--ink);
+            border: 1px solid rgba(236, 72, 153, 0.3);
+        }
+
+        .section {
+            margin-bottom: 32px;
+        }
+
+        .section:last-child {
+            margin-bottom: 0;
+        }
+
+        .item {
+            margin-bottom: 24px;
+            padding-left: 18px;
+            border-left: 3px solid rgba(236, 72, 153, 0.35);
+        }
+
+        .item:last-child {
+            margin-bottom: 0;
+        }
+
+        .item h3 {
+            margin: 0;
+            font-size: 18px;
+            letter-spacing: 0.01em;
+        }
+
+        .meta {
+            margin-top: 8px;
+            font-size: 12px;
+            color: var(--slate-600);
+        }
+
+        .item p {
+            margin-top: 12px;
+            font-size: 13px;
+            color: var(--slate-600);
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p style="text-align:center;">Email: {{ $data['email'] ?? '' }} | Phone: {{ $data['phone'] ?? '' }} | Birthday: {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            <strong>{{ $exp['title'] ?? '' }}</strong> – {{ $exp['company'] ?? '' }}<br>
-            {{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }}<br>
-            <i>{{ $exp['achievements'] ?? '' }}</i><br>
-            {{ $exp['about'] ?? '' }}
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="canvas">
+        <header>
+            <div class="heading">
+                <p class="eyebrow">{{ __('Creative Spirit') }}</p>
+                <h1 class="name">{{ $data['name'] ?? __('Your Name') }}</h1>
+                @if ($data['headline'])
+                    <p class="headline">{{ $data['headline'] }}</p>
+                @endif
+                @if (!empty($data['contacts']))
+                    <div class="contact">
+                        @foreach ($data['contacts'] as $contact)
+                            <span>{{ $contact }}</span>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </header>
+
+        <div class="body">
+            <aside class="sidebar">
+                @if ($data['summary'])
+                    <div class="card">
+                        <h2>{{ __('Artist Statement') }}</h2>
+                        <p>{{ $data['summary'] }}</p>
+                    </div>
+                @endif
+
+                @if (!empty($data['skills']))
+                    <div class="card">
+                        <h2>{{ __('Skill Palette') }}</h2>
+                        <div class="badge-list">
+                            @foreach ($data['skills'] as $skill)
+                                <span class="badge">{{ $skill }}</span>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <div class="card">
+                        <h2>{{ __('Playful Interests') }}</h2>
+                        <ul>
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <div class="card">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    {{ $language['name'] }}
+                                    @if (!empty($language['level']))
+                                        <span class="meta">&mdash; {{ ucfirst($language['level']) }}</span>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </aside>
+
+            <main>
+                @if (!empty($data['experiences']))
+                    <section class="section">
+                        <h2>{{ __('Featured Work') }}</h2>
+                        @foreach ($data['experiences'] as $experience)
+                            <article class="item">
+                                @if ($experience['role'])
+                                    <h3>{{ $experience['role'] }}</h3>
+                                @endif
+                                <div class="meta">
+                                    {{ $experience['company'] }}
+                                    @if ($experience['company'] && $experience['location'])
+                                        &middot;
+                                    @endif
+                                    {{ $experience['location'] }}
+                                    @if ($experience['period'])
+                                        &middot;
+                                        {{ $experience['period'] }}
+                                    @endif
+                                </div>
+                                @if ($experience['summary'])
+                                    <p>{{ $experience['summary'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </section>
+                @endif
+
+                @if (!empty($data['education']))
+                    <section class="section">
+                        <h2>{{ __('Learning Journey') }}</h2>
+                        @foreach ($data['education'] as $education)
+                            <article class="item">
+                                @if ($education['degree'])
+                                    <h3>{{ $education['degree'] }}</h3>
+                                @endif
+                                <div class="meta">
+                                    {{ $education['institution'] }}
+                                    @if ($education['institution'] && $education['location'])
+                                        &middot;
+                                    @endif
+                                    {{ $education['location'] }}
+                                    @if ($education['period'])
+                                        &middot;
+                                        {{ $education['period'] }}
+                                    @endif
+                                </div>
+                                @if ($education['field'])
+                                    <p>{{ $education['field'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </section>
+                @endif
+            </main>
         </div>
-    @endforeach
+    </div>
 </body>
 </html>

--- a/resources/views/templates/darkmode.blade.php
+++ b/resources/views/templates/darkmode.blade.php
@@ -1,24 +1,268 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Dark Mode</title>
+    <meta charset="UTF-8">
+    <title>Dark Mode · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Arial, sans-serif; background: #111827; color: #F9FAFB; }
-        h1 { color: #60A5FA; }
-        h2 { color: #93C5FD; }
-        .section { border-bottom: 1px solid #374151; margin: 15px 0; padding-bottom: 10px; }
+        :root {
+            --bg: #0f172a;
+            --panel: #111827;
+            --muted: #94a3b8;
+            --accent: #38bdf8;
+            --soft: #1e293b;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Space Grotesk", "Inter", sans-serif;
+            background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%), var(--bg);
+            color: #f8fafc;
+            font-size: 14px;
+            line-height: 1.6;
+            padding: 40px;
+        }
+
+        .shell {
+            max-width: 820px;
+            margin: 0 auto;
+            background: linear-gradient(145deg, rgba(17, 24, 39, 0.95), rgba(15, 23, 42, 0.95));
+            border-radius: 32px;
+            border: 1px solid rgba(56, 189, 248, 0.18);
+            overflow: hidden;
+            box-shadow: 0 40px 100px rgba(8, 47, 73, 0.25);
+        }
+
+        header {
+            padding: 48px 56px;
+            border-bottom: 1px solid rgba(56, 189, 248, 0.12);
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 34px;
+            letter-spacing: 0.05em;
+        }
+
+        header p {
+            margin: 12px 0 0;
+            font-size: 16px;
+            color: var(--muted);
+        }
+
+        .contact {
+            margin-top: 18px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 12px;
+            color: rgba(148, 163, 184, 0.85);
+        }
+
+        .content {
+            display: grid;
+            grid-template-columns: 1fr 260px;
+            gap: 40px;
+            padding: 48px 56px;
+        }
+
+        h2 {
+            margin: 0 0 18px;
+            font-size: 12px;
+            letter-spacing: 0.4em;
+            text-transform: uppercase;
+            color: rgba(148, 163, 184, 0.7);
+        }
+
+        .entry {
+            margin-bottom: 26px;
+        }
+
+        .entry:last-child {
+            margin-bottom: 0;
+        }
+
+        .entry h3 {
+            margin: 0;
+            font-size: 18px;
+            letter-spacing: 0.02em;
+            color: #e2e8f0;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 12px;
+            color: rgba(148, 163, 184, 0.8);
+        }
+
+        .entry p {
+            margin-top: 12px;
+            font-size: 13px;
+            color: rgba(226, 232, 240, 0.8);
+        }
+
+        .panel {
+            background: var(--soft);
+            border-radius: 24px;
+            padding: 24px;
+            border: 1px solid rgba(148, 163, 184, 0.12);
+            margin-bottom: 24px;
+        }
+
+        .panel:last-child {
+            margin-bottom: 0;
+        }
+
+        .chip-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .chip {
+            background: rgba(56, 189, 248, 0.12);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+            color: #e0f2fe;
+            border: 1px solid rgba(56, 189, 248, 0.2);
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>{{ $data['email'] ?? '' }} | {{ $data['phone'] ?? '' }} | {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            {{ $exp['title'] ?? '' }} at {{ $exp['company'] ?? '' }} ({{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }})
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="shell">
+        <header>
+            <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+            @if ($data['headline'])
+                <p>{{ $data['headline'] }}</p>
+            @endif
+            @if (!empty($data['contacts']))
+                <div class="contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <span>{{ $contact }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </header>
+
+        <div class="content">
+            <section>
+                @if ($data['summary'])
+                    <div class="entry">
+                        <h2>{{ __('Profile') }}</h2>
+                        <p>{{ $data['summary'] }}</p>
+                    </div>
+                @endif
+
+                @if (!empty($data['experiences']))
+                    <h2>{{ __('Experience') }}</h2>
+                    @foreach ($data['experiences'] as $experience)
+                        <article class="entry">
+                            @if ($experience['role'])
+                                <h3>{{ $experience['role'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $experience['company'] }}
+                                @if ($experience['company'] && $experience['location'])
+                                    &middot;
+                                @endif
+                                {{ $experience['location'] }}
+                                @if ($experience['period'])
+                                    &middot;
+                                    {{ $experience['period'] }}
+                                @endif
+                            </div>
+                            @if ($experience['summary'])
+                                <p>{{ $experience['summary'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+
+                @if (!empty($data['education']))
+                    <h2>{{ __('Education') }}</h2>
+                    @foreach ($data['education'] as $education)
+                        <article class="entry">
+                            @if ($education['degree'])
+                                <h3>{{ $education['degree'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $education['institution'] }}
+                                @if ($education['institution'] && $education['location'])
+                                    &middot;
+                                @endif
+                                {{ $education['location'] }}
+                                @if ($education['period'])
+                                    &middot;
+                                    {{ $education['period'] }}
+                                @endif
+                            </div>
+                            @if ($education['field'])
+                                <p>{{ $education['field'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+            </section>
+
+            <aside>
+                @if (!empty($data['skills']))
+                    <div class="panel">
+                        <h2>{{ __('Skills') }}</h2>
+                        <div class="chip-list">
+                            @foreach ($data['skills'] as $skill)
+                                <span class="chip">{{ $skill }}</span>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <div class="panel">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    {{ $language['name'] }}
+                                    @if (!empty($language['level']))
+                                        &mdash; {{ ucfirst($language['level']) }}
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <div class="panel">
+                        <h2>{{ __('Interests') }}</h2>
+                        <ul>
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </aside>
         </div>
-    @endforeach
+    </div>
 </body>
 </html>

--- a/resources/views/templates/elegant.blade.php
+++ b/resources/views/templates/elegant.blade.php
@@ -1,25 +1,265 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Elegant</title>
+    <meta charset="UTF-8">
+    <title>Elegant · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Georgia, serif; background: #FDF2F8; color: #831843; }
-        h1 { border-bottom: 2px solid #BE185D; padding-bottom: 5px; }
-        .section { margin: 20px 0; }
+        :root {
+            --charcoal: #1f2933;
+            --taupe: #6b7280;
+            --blush: #f5e1e5;
+            --gold: #d97706;
+            --paper: #fff9f2;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Cormorant Garamond", "Georgia", serif;
+            background: linear-gradient(140deg, rgba(245, 225, 229, 0.7), rgba(255, 249, 242, 0.9));
+            color: var(--charcoal);
+            font-size: 15px;
+            line-height: 1.6;
+            padding: 40px;
+        }
+
+        .sheet {
+            background: var(--paper);
+            border-radius: 32px;
+            padding: 52px 64px;
+            max-width: 780px;
+            margin: 0 auto;
+            box-shadow: 0 25px 60px rgba(31, 41, 51, 0.12);
+            border: 1px solid rgba(217, 119, 6, 0.12);
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 48px;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 44px;
+            letter-spacing: 0.08em;
+        }
+
+        header p {
+            margin: 12px 0 0;
+            font-size: 18px;
+            color: var(--taupe);
+        }
+
+        .contact {
+            margin-top: 24px;
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 16px;
+            font-size: 13px;
+            color: var(--taupe);
+        }
+
+        .rule {
+            height: 1px;
+            background: linear-gradient(to right, transparent, rgba(217, 119, 6, 0.6), transparent);
+            margin: 40px 0;
+        }
+
+        h2 {
+            margin: 0 0 20px;
+            text-transform: uppercase;
+            letter-spacing: 0.4em;
+            font-size: 13px;
+            color: rgba(31, 41, 51, 0.6);
+        }
+
+        .item {
+            margin-bottom: 28px;
+        }
+
+        .item:last-child {
+            margin-bottom: 0;
+        }
+
+        .item h3 {
+            margin: 0;
+            font-size: 22px;
+            letter-spacing: 0.06em;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 14px;
+            color: var(--taupe);
+            font-style: italic;
+        }
+
+        .item p {
+            margin-top: 12px;
+            color: var(--taupe);
+            font-size: 15px;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        .list-columns {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 16px;
+        }
+
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid rgba(217, 119, 6, 0.3);
+            font-size: 13px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>Email: {{ $data['email'] ?? '' }} | Phone: {{ $data['phone'] ?? '' }} | Birthday: {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            <strong>{{ $exp['title'] ?? '' }}</strong> at {{ $exp['company'] ?? '' }}<br>
-            <i>{{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }}</i><br>
-            {{ $exp['about'] ?? '' }}
-        </div>
-    @endforeach
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="sheet">
+        <header>
+            <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+            @if ($data['headline'])
+                <p>{{ $data['headline'] }}</p>
+            @endif
+            @if (!empty($data['contacts']))
+                <div class="contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <span>{{ $contact }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </header>
+
+        @if ($data['summary'])
+            <section>
+                <h2>{{ __('Profile') }}</h2>
+                <p>{{ $data['summary'] }}</p>
+                <div class="rule"></div>
+            </section>
+        @endif
+
+        @if (!empty($data['experiences']))
+            <section>
+                <h2>{{ __('Experience') }}</h2>
+                @foreach ($data['experiences'] as $experience)
+                    <article class="item">
+                        @if ($experience['role'])
+                            <h3>{{ $experience['role'] }}</h3>
+                        @endif
+                        <div class="meta">
+                            {{ $experience['company'] }}
+                            @if ($experience['company'] && $experience['location'])
+                                &bull;
+                            @endif
+                            {{ $experience['location'] }}
+                            @if ($experience['period'])
+                                &bull;
+                                {{ $experience['period'] }}
+                            @endif
+                        </div>
+                        @if ($experience['summary'])
+                            <p>{{ $experience['summary'] }}</p>
+                        @endif
+                    </article>
+                @endforeach
+                <div class="rule"></div>
+            </section>
+        @endif
+
+        @if (!empty($data['education']))
+            <section>
+                <h2>{{ __('Education') }}</h2>
+                @foreach ($data['education'] as $education)
+                    <article class="item">
+                        @if ($education['degree'])
+                            <h3>{{ $education['degree'] }}</h3>
+                        @endif
+                        <div class="meta">
+                            {{ $education['institution'] }}
+                            @if ($education['institution'] && $education['location'])
+                                &bull;
+                            @endif
+                            {{ $education['location'] }}
+                            @if ($education['period'])
+                                &bull;
+                                {{ $education['period'] }}
+                            @endif
+                        </div>
+                        @if ($education['field'])
+                            <p>{{ $education['field'] }}</p>
+                        @endif
+                    </article>
+                @endforeach
+                <div class="rule"></div>
+            </section>
+        @endif
+
+        @if (!empty($data['skills']))
+            <section>
+                <h2>{{ __('Expertise') }}</h2>
+                <div class="list-columns">
+                    @foreach ($data['skills'] as $skill)
+                        <span class="tag">{{ $skill }}</span>
+                    @endforeach
+                </div>
+                <div class="rule"></div>
+            </section>
+        @endif
+
+        @if (!empty($data['languages']) || !empty($data['hobbies']))
+            <section>
+                <h2>{{ __('Refinements') }}</h2>
+                <div class="list-columns">
+                    <div>
+                        @if (!empty($data['languages']))
+                            <strong>{{ __('Languages') }}</strong>
+                            <ul>
+                                @foreach ($data['languages'] as $language)
+                                    <li>
+                                        {{ $language['name'] }}
+                                        @if (!empty($language['level']))
+                                            &mdash; {{ ucfirst($language['level']) }}
+                                        @endif
+                                    </li>
+                                @endforeach
+                            </ul>
+                        @endif
+                    </div>
+                    <div>
+                        @if (!empty($data['hobbies']))
+                            <strong>{{ __('Interests') }}</strong>
+                            <ul>
+                                @foreach ($data['hobbies'] as $hobby)
+                                    <li>{{ $hobby }}</li>
+                                @endforeach
+                            </ul>
+                        @endif
+                    </div>
+                </div>
+            </section>
+        @endif
+    </div>
 </body>
 </html>

--- a/resources/views/templates/futuristic.blade.php
+++ b/resources/views/templates/futuristic.blade.php
@@ -1,24 +1,275 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Futuristic</title>
+    <meta charset="UTF-8">
+    <title>Futuristic · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: "Orbitron", sans-serif; background: black; color: #00F5FF; }
-        h1 { font-size: 34px; border-bottom: 2px solid #00F5FF; }
-        .section { background: rgba(0,245,255,0.1); padding: 15px; margin: 15px 0; border-radius: 8px; }
+        :root {
+            --midnight: #0b1120;
+            --violet: #7c3aed;
+            --cyan: #22d3ee;
+            --magenta: #f472b6;
+            --text: #f8fafc;
+            --muted: #a5b4fc;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Archivo", "Inter", sans-serif;
+            background: radial-gradient(circle at 20% 20%, rgba(124, 58, 237, 0.28), transparent 55%),
+                radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.24), transparent 50%),
+                var(--midnight);
+            color: var(--text);
+            font-size: 13px;
+            line-height: 1.6;
+            padding: 40px;
+        }
+
+        .grid {
+            max-width: 880px;
+            margin: 0 auto;
+            border-radius: 36px;
+            border: 1px solid rgba(124, 58, 237, 0.2);
+            overflow: hidden;
+            background: linear-gradient(140deg, rgba(15, 23, 42, 0.92), rgba(12, 10, 43, 0.95));
+            box-shadow: 0 40px 120px rgba(15, 23, 42, 0.35);
+        }
+
+        header {
+            padding: 48px 60px;
+            border-bottom: 1px solid rgba(124, 58, 237, 0.2);
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 32px;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+        }
+
+        header p {
+            margin: 14px 0 0;
+            font-size: 15px;
+            color: var(--muted);
+        }
+
+        .contact {
+            margin-top: 18px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 11px;
+            color: rgba(165, 180, 252, 0.85);
+        }
+
+        .body {
+            display: grid;
+            grid-template-columns: 1fr 260px;
+            gap: 40px;
+            padding: 48px 60px;
+        }
+
+        h2 {
+            margin: 0 0 18px;
+            font-size: 12px;
+            letter-spacing: 0.5em;
+            text-transform: uppercase;
+            color: rgba(165, 180, 252, 0.7);
+        }
+
+        .entry {
+            margin-bottom: 26px;
+            border-left: 3px solid rgba(124, 58, 237, 0.35);
+            padding-left: 18px;
+        }
+
+        .entry:last-child {
+            margin-bottom: 0;
+        }
+
+        .entry h3 {
+            margin: 0;
+            font-size: 18px;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 11px;
+            color: rgba(165, 180, 252, 0.85);
+        }
+
+        .entry p {
+            margin-top: 12px;
+            font-size: 13px;
+            color: rgba(226, 232, 240, 0.85);
+        }
+
+        .panel {
+            background: linear-gradient(145deg, rgba(124, 58, 237, 0.18), rgba(34, 211, 238, 0.18));
+            border-radius: 24px;
+            padding: 24px;
+            border: 1px solid rgba(124, 58, 237, 0.2);
+            margin-bottom: 24px;
+        }
+
+        .panel:last-child {
+            margin-bottom: 0;
+        }
+
+        .chip-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .chip {
+            background: rgba(124, 58, 237, 0.2);
+            color: var(--text);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>{{ $data['email'] ?? '' }} • {{ $data['phone'] ?? '' }} • {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            {{ $exp['title'] ?? '' }} @ {{ $exp['company'] ?? '' }}<br>
-            {{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }}
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="grid">
+        <header>
+            <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+            @if ($data['headline'])
+                <p>{{ $data['headline'] }}</p>
+            @endif
+            @if (!empty($data['contacts']))
+                <div class="contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <span>{{ $contact }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </header>
+
+        <div class="body">
+            <section>
+                @if ($data['summary'])
+                    <div class="entry" style="border-left-color: rgba(244, 114, 182, 0.45);">
+                        <h2>{{ __('Profile') }}</h2>
+                        <p>{{ $data['summary'] }}</p>
+                    </div>
+                @endif
+
+                @if (!empty($data['experiences']))
+                    <h2>{{ __('Experience') }}</h2>
+                    @foreach ($data['experiences'] as $experience)
+                        <article class="entry">
+                            @if ($experience['role'])
+                                <h3>{{ $experience['role'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $experience['company'] }}
+                                @if ($experience['company'] && $experience['location'])
+                                    &middot;
+                                @endif
+                                {{ $experience['location'] }}
+                                @if ($experience['period'])
+                                    &middot;
+                                    {{ $experience['period'] }}
+                                @endif
+                            </div>
+                            @if ($experience['summary'])
+                                <p>{{ $experience['summary'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+
+                @if (!empty($data['education']))
+                    <h2>{{ __('Education') }}</h2>
+                    @foreach ($data['education'] as $education)
+                        <article class="entry">
+                            @if ($education['degree'])
+                                <h3>{{ $education['degree'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $education['institution'] }}
+                                @if ($education['institution'] && $education['location'])
+                                    &middot;
+                                @endif
+                                {{ $education['location'] }}
+                                @if ($education['period'])
+                                    &middot;
+                                    {{ $education['period'] }}
+                                @endif
+                            </div>
+                            @if ($education['field'])
+                                <p>{{ $education['field'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+            </section>
+
+            <aside>
+                @if (!empty($data['skills']))
+                    <div class="panel">
+                        <h2>{{ __('Skills') }}</h2>
+                        <div class="chip-list">
+                            @foreach ($data['skills'] as $skill)
+                                <span class="chip">{{ $skill }}</span>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <div class="panel">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    {{ $language['name'] }}
+                                    @if (!empty($language['level']))
+                                        &mdash; {{ ucfirst($language['level']) }}
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <div class="panel">
+                        <h2>{{ __('Interests') }}</h2>
+                        <ul>
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </aside>
         </div>
-    @endforeach
+    </div>
 </body>
 </html>

--- a/resources/views/templates/gradient.blade.php
+++ b/resources/views/templates/gradient.blade.php
@@ -1,24 +1,268 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Gradient</title>
+    <meta charset="UTF-8">
+    <title>Gradient · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Arial, sans-serif; background: linear-gradient(to right, #6366F1, #EC4899); color: white; padding: 20px; }
-        h1 { font-size: 32px; margin-bottom: 0; }
-        .section { background: rgba(255,255,255,0.1); padding: 15px; border-radius: 10px; margin: 15px 0; }
+        :root {
+            --emerald: #34d399;
+            --teal: #14b8a6;
+            --cyan: #22d3ee;
+            --slate-900: #0f172a;
+            --slate-500: #64748b;
+            --slate-200: #e2e8f0;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            font-family: "Manrope", "Helvetica Neue", Arial, sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            color: var(--slate-900);
+            background: linear-gradient(135deg, rgba(52, 211, 153, 0.4), rgba(34, 211, 238, 0.45));
+            padding: 40px;
+        }
+
+        .wrapper {
+            max-width: 860px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 36px;
+            overflow: hidden;
+            box-shadow: 0 30px 90px rgba(15, 23, 42, 0.18);
+        }
+
+        header {
+            background: linear-gradient(120deg, rgba(52, 211, 153, 0.92), rgba(20, 184, 166, 0.92));
+            color: #fff;
+            padding: 48px 60px 56px;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 36px;
+            letter-spacing: 0.03em;
+        }
+
+        header p {
+            margin: 10px 0 0;
+            font-size: 16px;
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .contact {
+            margin-top: 20px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .content {
+            padding: 48px 60px;
+            display: grid;
+            grid-template-columns: 1fr 280px;
+            gap: 40px;
+        }
+
+        h2 {
+            margin: 0 0 18px;
+            font-size: 12px;
+            letter-spacing: 0.35em;
+            text-transform: uppercase;
+            color: var(--slate-500);
+        }
+
+        .entry {
+            margin-bottom: 26px;
+            padding-bottom: 20px;
+            border-bottom: 1px solid rgba(226, 232, 240, 0.8);
+        }
+
+        .entry:last-child {
+            border-bottom: none;
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
+
+        .entry h3 {
+            margin: 0;
+            font-size: 18px;
+            letter-spacing: 0.01em;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 12px;
+            color: var(--slate-500);
+        }
+
+        .entry p {
+            margin-top: 12px;
+            font-size: 13px;
+            color: var(--slate-500);
+        }
+
+        .card {
+            background: linear-gradient(145deg, rgba(52, 211, 153, 0.12), rgba(34, 211, 238, 0.18));
+            border-radius: 24px;
+            padding: 24px;
+            border: 1px solid rgba(20, 184, 166, 0.2);
+            margin-bottom: 24px;
+        }
+
+        .card:last-child {
+            margin-bottom: 0;
+        }
+
+        .pill-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .pill {
+            background: rgba(15, 23, 42, 0.08);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>{{ $data['email'] ?? '' }} • {{ $data['phone'] ?? '' }} • {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            {{ $exp['title'] ?? '' }} - {{ $exp['company'] ?? '' }}<br>
-            {{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }}
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="wrapper">
+        <header>
+            <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+            @if ($data['headline'])
+                <p>{{ $data['headline'] }}</p>
+            @endif
+            @if (!empty($data['contacts']))
+                <div class="contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <span>{{ $contact }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </header>
+
+        <div class="content">
+            <section>
+                @if ($data['summary'])
+                    <div class="entry" style="border-bottom: none; margin-bottom: 32px; padding-bottom: 0;">
+                        <h2>{{ __('Profile') }}</h2>
+                        <p>{{ $data['summary'] }}</p>
+                    </div>
+                @endif
+
+                @if (!empty($data['experiences']))
+                    <h2>{{ __('Experience') }}</h2>
+                    @foreach ($data['experiences'] as $experience)
+                        <article class="entry">
+                            @if ($experience['role'])
+                                <h3>{{ $experience['role'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $experience['company'] }}
+                                @if ($experience['company'] && $experience['location'])
+                                    &middot;
+                                @endif
+                                {{ $experience['location'] }}
+                                @if ($experience['period'])
+                                    &middot;
+                                    {{ $experience['period'] }}
+                                @endif
+                            </div>
+                            @if ($experience['summary'])
+                                <p>{{ $experience['summary'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+
+                @if (!empty($data['education']))
+                    <h2>{{ __('Education') }}</h2>
+                    @foreach ($data['education'] as $education)
+                        <article class="entry">
+                            @if ($education['degree'])
+                                <h3>{{ $education['degree'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $education['institution'] }}
+                                @if ($education['institution'] && $education['location'])
+                                    &middot;
+                                @endif
+                                {{ $education['location'] }}
+                                @if ($education['period'])
+                                    &middot;
+                                    {{ $education['period'] }}
+                                @endif
+                            </div>
+                            @if ($education['field'])
+                                <p>{{ $education['field'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                @endif
+            </section>
+
+            <aside>
+                @if (!empty($data['skills']))
+                    <div class="card">
+                        <h2>{{ __('Skills') }}</h2>
+                        <div class="pill-list">
+                            @foreach ($data['skills'] as $skill)
+                                <span class="pill">{{ $skill }}</span>
+                            @endforeach
+                        </div>
+                    </div>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <div class="card">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    {{ $language['name'] }}
+                                    @if (!empty($language['level']))
+                                        &mdash; {{ ucfirst($language['level']) }}
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <div class="card">
+                        <h2>{{ __('Interests') }}</h2>
+                        <ul>
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+            </aside>
         </div>
-    @endforeach
+    </div>
 </body>
 </html>

--- a/resources/views/templates/minimal.blade.php
+++ b/resources/views/templates/minimal.blade.php
@@ -1,24 +1,250 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Minimal</title>
+    <meta charset="UTF-8">
+    <title>Minimal · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Helvetica, sans-serif; color: #111; }
-        h1 { font-size: 28px; margin-bottom: 0; }
-        h2 { font-size: 20px; margin-top: 30px; }
-        .section { margin-bottom: 15px; }
+        :root {
+            --ink: #0f172a;
+            --muted: #64748b;
+            --border: #e2e8f0;
+            --soft: #f8fafc;
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            font-family: "IBM Plex Sans", Arial, sans-serif;
+            color: var(--ink);
+            background: var(--soft);
+            padding: 48px;
+            font-size: 13px;
+            line-height: 1.7;
+        }
+
+        .page {
+            max-width: 760px;
+            margin: 0 auto;
+            background: #fff;
+            border-radius: 28px;
+            border: 1px solid var(--border);
+            padding: 48px 60px;
+            box-shadow: 0 30px 80px rgba(15, 23, 42, 0.08);
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 48px;
+        }
+
+        header h1 {
+            margin: 0;
+            font-size: 30px;
+            letter-spacing: 0.04em;
+        }
+
+        header p {
+            margin: 10px 0 0;
+            color: var(--muted);
+            font-size: 14px;
+        }
+
+        .contact {
+            margin-top: 24px;
+            display: flex;
+            justify-content: center;
+            flex-wrap: wrap;
+            gap: 12px;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .section {
+            margin-bottom: 36px;
+        }
+
+        .section:last-child {
+            margin-bottom: 0;
+        }
+
+        .section h2 {
+            margin: 0 0 16px;
+            font-size: 12px;
+            letter-spacing: 0.4em;
+            text-transform: uppercase;
+            color: var(--muted);
+        }
+
+        .item {
+            margin-bottom: 24px;
+        }
+
+        .item:last-child {
+            margin-bottom: 0;
+        }
+
+        .item h3 {
+            margin: 0;
+            font-size: 16px;
+            letter-spacing: 0.01em;
+        }
+
+        .meta {
+            margin-top: 6px;
+            font-size: 12px;
+            color: var(--muted);
+        }
+
+        .item p {
+            margin-top: 12px;
+            color: var(--muted);
+            font-size: 13px;
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
+
+        .pill-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .pill {
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 6px 14px;
+            font-size: 12px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p>{{ $data['email'] ?? '' }} • {{ $data['phone'] ?? '' }} • {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            <strong>{{ $exp['title'] ?? '' }}</strong>, {{ $exp['company'] ?? '' }} ({{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }})
-        </div>
-    @endforeach
+    @php
+        $data = $templateData;
+    @endphp
+
+    <div class="page">
+        <header>
+            <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+            @if ($data['headline'])
+                <p>{{ $data['headline'] }}</p>
+            @endif
+            @if (!empty($data['contacts']))
+                <div class="contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <span>{{ $contact }}</span>
+                    @endforeach
+                </div>
+            @endif
+        </header>
+
+        @if ($data['summary'])
+            <section class="section">
+                <h2>{{ __('Profile') }}</h2>
+                <p>{{ $data['summary'] }}</p>
+            </section>
+        @endif
+
+        @if (!empty($data['experiences']))
+            <section class="section">
+                <h2>{{ __('Experience') }}</h2>
+                @foreach ($data['experiences'] as $experience)
+                    <article class="item">
+                        @if ($experience['role'])
+                            <h3>{{ $experience['role'] }}</h3>
+                        @endif
+                        <div class="meta">
+                            {{ $experience['company'] }}
+                            @if ($experience['company'] && $experience['location'])
+                                &middot;
+                            @endif
+                            {{ $experience['location'] }}
+                            @if ($experience['period'])
+                                &middot;
+                                {{ $experience['period'] }}
+                            @endif
+                        </div>
+                        @if ($experience['summary'])
+                            <p>{{ $experience['summary'] }}</p>
+                        @endif
+                    </article>
+                @endforeach
+            </section>
+        @endif
+
+        @if (!empty($data['education']))
+            <section class="section">
+                <h2>{{ __('Education') }}</h2>
+                @foreach ($data['education'] as $education)
+                    <article class="item">
+                        @if ($education['institution'])
+                            <h3>{{ $education['institution'] }}</h3>
+                        @endif
+                        <div class="meta">
+                            {{ $education['degree'] }}
+                            @if ($education['degree'] && $education['location'])
+                                &middot;
+                            @endif
+                            {{ $education['location'] }}
+                            @if ($education['period'])
+                                &middot;
+                                {{ $education['period'] }}
+                            @endif
+                        </div>
+                        @if ($education['field'])
+                            <p>{{ $education['field'] }}</p>
+                        @endif
+                    </article>
+                @endforeach
+            </section>
+        @endif
+
+        @if (!empty($data['skills']))
+            <section class="section">
+                <h2>{{ __('Skills') }}</h2>
+                <div class="pill-list">
+                    @foreach ($data['skills'] as $skill)
+                        <span class="pill">{{ $skill }}</span>
+                    @endforeach
+                </div>
+            </section>
+        @endif
+
+        @if (!empty($data['languages']))
+            <section class="section">
+                <h2>{{ __('Languages') }}</h2>
+                <ul>
+                    @foreach ($data['languages'] as $language)
+                        <li>
+                            {{ $language['name'] }}
+                            @if (!empty($language['level']))
+                                &mdash; {{ ucfirst($language['level']) }}
+                            @endif
+                        </li>
+                    @endforeach
+                </ul>
+            </section>
+        @endif
+
+        @if (!empty($data['hobbies']))
+            <section class="section">
+                <h2>{{ __('Interests') }}</h2>
+                <ul>
+                    @foreach ($data['hobbies'] as $hobby)
+                        <li>{{ $hobby }}</li>
+                    @endforeach
+                </ul>
+            </section>
+        @endif
+    </div>
 </body>
 </html>

--- a/resources/views/templates/modern.blade.php
+++ b/resources/views/templates/modern.blade.php
@@ -1,27 +1,288 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-    <meta charset="utf-8">
-    <title>CV - Modern</title>
+    <meta charset="UTF-8">
+    <title>Modern · {{ config('app.name', 'CreateIt') }}</title>
     <style>
-        body { font-family: Arial, sans-serif; background: #F9FAFB; color: #111827; }
-        h1 { background: #2563EB; color: white; padding: 10px; border-radius: 6px; }
-        .section { margin: 20px 0; padding: 10px; border-left: 4px solid #2563EB; }
+        :root {
+            --blue-700: #1d4ed8;
+            --blue-500: #2563eb;
+            --slate-900: #0f172a;
+            --slate-600: #475569;
+            --slate-200: #e2e8f0;
+            --slate-100: #f1f5f9;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+            background: var(--slate-100);
+            color: var(--slate-900);
+            font-size: 14px;
+            line-height: 1.6;
+            padding: 36px;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: 260px 1fr;
+            border-radius: 28px;
+            overflow: hidden;
+            border: 1px solid var(--slate-200);
+            box-shadow: 0 24px 60px rgba(15, 23, 42, 0.12);
+        }
+
+        aside {
+            background: linear-gradient(160deg, var(--blue-700), var(--blue-500));
+            color: #fff;
+            padding: 40px 32px;
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        aside h2 {
+            font-size: 12px;
+            letter-spacing: 0.32em;
+            text-transform: uppercase;
+            margin: 0 0 12px;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .avatar {
+            width: 88px;
+            height: 88px;
+            border-radius: 20px;
+            background: rgba(255, 255, 255, 0.1);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 32px;
+            font-weight: 600;
+            margin-bottom: 20px;
+        }
+
+        .name {
+            font-size: 22px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            margin: 0;
+        }
+
+        .headline {
+            color: rgba(255, 255, 255, 0.75);
+            font-size: 14px;
+            margin-top: 6px;
+        }
+
+        .contact {
+            display: grid;
+            gap: 8px;
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.75);
+        }
+
+        .summary {
+            background: rgba(15, 23, 42, 0.12);
+            border-radius: 16px;
+            padding: 18px;
+            font-size: 13px;
+            color: rgba(255, 255, 255, 0.85);
+        }
+
+        .tag-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .tag {
+            background: rgba(15, 23, 42, 0.18);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 12px;
+            color: #fff;
+        }
+
+        main {
+            background: #fff;
+            padding: 48px;
+            display: flex;
+            flex-direction: column;
+            gap: 40px;
+        }
+
+        main h2 {
+            font-size: 12px;
+            letter-spacing: 0.32em;
+            text-transform: uppercase;
+            margin: 0 0 20px;
+            color: var(--slate-600);
+        }
+
+        .entry {
+            margin-bottom: 24px;
+        }
+
+        .entry:last-child {
+            margin-bottom: 0;
+        }
+
+        .entry h3 {
+            margin: 0;
+            font-size: 17px;
+            color: var(--slate-900);
+            letter-spacing: 0.01em;
+        }
+
+        .entry .meta {
+            margin-top: 6px;
+            font-size: 12px;
+            color: var(--slate-600);
+        }
+
+        .entry p {
+            margin-top: 12px;
+            font-size: 13px;
+            color: var(--slate-600);
+        }
+
+        ul {
+            margin: 0;
+            padding-left: 18px;
+        }
+
+        li {
+            margin-bottom: 8px;
+        }
     </style>
 </head>
 <body>
-    <h1>{{ $data['name'] ?? '' }}</h1>
-    <p><strong>Email:</strong> {{ $data['email'] ?? '' }} | <strong>Phone:</strong> {{ $data['phone'] ?? '' }} | <strong>Birthday:</strong> {{ $data['birthday'] ?? '' }}</p>
+    @include('templates.partials.base-data', ['cv' => $cv])
 
-    <h2>Experience</h2>
-    @foreach($data['experience'] ?? [] as $exp)
-        <div class="section">
-            <h3>{{ $exp['title'] ?? '' }}</h3>
-            <p>{{ $exp['company'] ?? '' }} ({{ $exp['start'] ?? '' }} - {{ $exp['current'] ? 'Present' : ($exp['end'] ?? '') }})</p>
-            <p>{{ $exp['city'] ?? '' }}, {{ $exp['country'] ?? '' }}</p>
-            <p><em>{{ $exp['achievements'] ?? '' }}</em></p>
-            <p>{{ $exp['about'] ?? '' }}</p>
-        </div>
-    @endforeach
+    @php
+        $data = $templateData;
+        $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
+            ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+            ->map(fn ($item) => mb_strtoupper(mb_substr(trim($item), 0, 1)))
+            ->implode('');
+    @endphp
+
+    <div class="grid">
+        <aside>
+            <div>
+                <div class="avatar">{{ $initials !== '' ? $initials : 'CV' }}</div>
+                <p class="name">{{ $data['name'] ?? __('Your Name') }}</p>
+                @if ($data['headline'])
+                    <p class="headline">{{ $data['headline'] }}</p>
+                @endif
+            </div>
+
+            @if (!empty($data['contacts']))
+                <div>
+                    <h2>{{ __('Contact') }}</h2>
+                    <div class="contact">
+                        @foreach ($data['contacts'] as $contact)
+                            <div>{{ $contact }}</div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            @if ($data['summary'])
+                <div>
+                    <h2>{{ __('About') }}</h2>
+                    <div class="summary">{{ $data['summary'] }}</div>
+                </div>
+            @endif
+
+            @if (!empty($data['skills']))
+                <div>
+                    <h2>{{ __('Skills') }}</h2>
+                    <div class="tag-list">
+                        @foreach ($data['skills'] as $skill)
+                            <span class="tag">{{ $skill }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        </aside>
+
+        <main>
+            @if (!empty($data['experiences']))
+                <section>
+                    <h2>{{ __('Experience') }}</h2>
+                    @foreach ($data['experiences'] as $experience)
+                        <article class="entry">
+                            @if ($experience['role'])
+                                <h3>{{ $experience['role'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $experience['company'] }}
+                                @if ($experience['company'] && $experience['location'])
+                                    &middot;
+                                @endif
+                                {{ $experience['location'] }}
+                                @if ($experience['period'])
+                                    &middot;
+                                    {{ $experience['period'] }}
+                                @endif
+                            </div>
+                            @if ($experience['summary'])
+                                <p>{{ $experience['summary'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                </section>
+            @endif
+
+            @if (!empty($data['education']))
+                <section>
+                    <h2>{{ __('Education') }}</h2>
+                    @foreach ($data['education'] as $education)
+                        <article class="entry">
+                            @if ($education['institution'])
+                                <h3>{{ $education['institution'] }}</h3>
+                            @endif
+                            <div class="meta">
+                                {{ $education['degree'] }}
+                                @if ($education['degree'] && $education['location'])
+                                    &middot;
+                                @endif
+                                {{ $education['location'] }}
+                                @if ($education['period'])
+                                    &middot;
+                                    {{ $education['period'] }}
+                                @endif
+                            </div>
+                            @if ($education['field'])
+                                <p>{{ $education['field'] }}</p>
+                            @endif
+                        </article>
+                    @endforeach
+                </section>
+            @endif
+
+            @if (!empty($data['languages']))
+                <section>
+                    <h2>{{ __('Languages') }}</h2>
+                    <ul>
+                        @foreach ($data['languages'] as $language)
+                            <li>
+                                {{ $language['name'] }}
+                                @if (!empty($language['level']))
+                                    &mdash; {{ ucfirst($language['level']) }}
+                                @endif
+                            </li>
+                        @endforeach
+                    </ul>
+                </section>
+            @endif
+        </main>
+    </div>
 </body>
 </html>

--- a/resources/views/templates/partials/base-data.blade.php
+++ b/resources/views/templates/partials/base-data.blade.php
@@ -1,0 +1,266 @@
+@php
+    use Illuminate\Support\Carbon;
+    use Throwable;
+
+    $value = fn(string $key, $default = null) => data_get($cv, $key, $default);
+
+    $firstName = $value('first_name');
+    $lastName = $value('last_name');
+    $fullName = collect([$firstName, $lastName])
+        ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+        ->map(fn ($item) => trim($item))
+        ->implode(' ');
+    $fullName = $fullName !== '' ? $fullName : null;
+
+    $headline = $value('headline') ?? $value('title');
+    $summary = $value('summary') ?? $value('about');
+
+    $email = $value('email');
+    $phone = $value('phone');
+    $website = $value('website');
+    $city = $value('city');
+    $country = $value('country');
+    $location = collect([$city, $country])
+        ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+        ->map(fn ($item) => trim($item))
+        ->implode(', ');
+    $location = $location !== '' ? $location : null;
+
+    $birthdayRaw = $value('birthday');
+    $birthdayFormatted = null;
+    if ($birthdayRaw instanceof Carbon) {
+        $birthdayFormatted = $birthdayRaw->translatedFormat('F j, Y');
+    } elseif (is_string($birthdayRaw) && trim($birthdayRaw) !== '') {
+        try {
+            $birthdayFormatted = Carbon::parse($birthdayRaw)->translatedFormat('F j, Y');
+        } catch (Throwable $exception) {
+            $birthdayFormatted = $birthdayRaw;
+        }
+    }
+
+    $formatMonthYear = function ($value) {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+
+        try {
+            if (preg_match('/^\d{4}-\d{2}$/', $value)) {
+                return Carbon::createFromFormat('Y-m', $value)->translatedFormat('M Y');
+            }
+
+            return Carbon::parse($value)->translatedFormat('M Y');
+        } catch (Throwable $exception) {
+            return $value;
+        }
+    };
+
+    $formatYear = function ($value) use ($formatMonthYear) {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = trim($value);
+
+        try {
+            if (preg_match('/^\d{4}$/', $value)) {
+                return Carbon::createFromFormat('Y', $value)->translatedFormat('Y');
+            }
+
+            return $formatMonthYear($value);
+        } catch (Throwable $exception) {
+            return $value;
+        }
+    };
+
+    $normaliseCollection = function ($items) {
+        if ($items instanceof \Illuminate\Support\Collection) {
+            $items = $items->all();
+        }
+
+        if (is_string($items)) {
+            $decoded = json_decode($items, true);
+            $items = is_array($decoded) ? $decoded : [];
+        }
+
+        if (!is_array($items)) {
+            return collect();
+        }
+
+        $collection = collect($items);
+        if ($collection->isEmpty()) {
+            return collect();
+        }
+
+        if ($collection->isAssoc()) {
+            $collection = collect([$collection->all()]);
+        }
+
+        return $collection
+            ->map(function ($item) {
+                if ($item instanceof \Illuminate\Support\Collection) {
+                    return $item->toArray();
+                }
+
+                if (is_object($item)) {
+                    return collect(get_object_vars($item))->toArray();
+                }
+
+                return is_array($item) ? $item : [];
+            })
+            ->filter(fn ($item) => !empty(array_filter($item, fn ($value) => is_array($value) ? !empty($value) : trim((string) $value) !== '')))
+            ->values();
+    };
+
+    $experienceItems = $normaliseCollection($value('work_experience', $value('experience', [])))->map(function ($experience) use ($formatMonthYear) {
+        $role = $experience['position'] ?? $experience['role'] ?? null;
+        $company = $experience['company'] ?? null;
+        $location = collect([
+            $experience['city'] ?? null,
+            $experience['country'] ?? null,
+        ])
+            ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+            ->map(fn ($item) => trim($item))
+            ->implode(', ');
+        $location = $location !== '' ? $location : null;
+
+        $fromRaw = $experience['from'] ?? null;
+        $toRaw = $experience['to'] ?? null;
+        $from = $formatMonthYear($fromRaw);
+        $isCurrent = !empty($experience['currently']);
+        $to = $isCurrent ? __('Present') : $formatMonthYear($toRaw);
+        $period = collect([$from, $to])->filter()->implode(' – ');
+
+        $summary = $experience['achievements'] ?? $experience['description'] ?? null;
+
+        return [
+            'role' => $role,
+            'company' => $company,
+            'location' => $location,
+            'from' => $from,
+            'to' => $to,
+            'from_raw' => $fromRaw,
+            'to_raw' => $toRaw,
+            'is_current' => $isCurrent,
+            'period' => $period !== '' ? $period : null,
+            'summary' => is_string($summary) && trim($summary) !== '' ? trim($summary) : null,
+        ];
+    })->filter(function ($item) {
+        return ($item['role'] ?? null) || ($item['company'] ?? null) || ($item['summary'] ?? null);
+    })->values();
+
+    $educationItems = $normaliseCollection($value('education', []))->map(function ($education) use ($formatYear) {
+        $institution = $education['institution'] ?? $education['school'] ?? null;
+        $degree = $education['degree'] ?? null;
+        $field = $education['field'] ?? null;
+        $location = collect([
+            $education['city'] ?? null,
+            $education['country'] ?? null,
+        ])
+            ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+            ->map(fn ($item) => trim($item))
+            ->implode(', ');
+        $location = $location !== '' ? $location : null;
+
+        $start = $formatYear($education['start_year'] ?? $education['from'] ?? null);
+        $end = $formatYear($education['end_year'] ?? $education['to'] ?? null);
+        $period = collect([$start, $end])->filter()->implode(' – ');
+
+        return [
+            'institution' => $institution,
+            'degree' => $degree,
+            'field' => $field,
+            'location' => $location,
+            'start' => $start,
+            'end' => $end,
+            'period' => $period !== '' ? $period : null,
+        ];
+    })->filter(function ($item) {
+        return ($item['institution'] ?? null) || ($item['degree'] ?? null) || ($item['field'] ?? null);
+    })->values();
+
+    $skillsItems = collect($value('skills', []))
+        ->map(function ($item) {
+            if (is_string($item)) {
+                return trim($item);
+            }
+
+            if (is_array($item)) {
+                $label = $item['name'] ?? $item['title'] ?? null;
+                return is_string($label) ? trim($label) : null;
+            }
+
+            return null;
+        })
+        ->filter(fn ($item) => is_string($item) && $item !== '')
+        ->values();
+
+    $languageItems = collect($value('languages', []))
+        ->map(function ($item) {
+            if (is_string($item)) {
+                return ['name' => trim($item), 'level' => null];
+            }
+
+            if (is_array($item)) {
+                $name = isset($item['name']) ? trim((string) $item['name']) : null;
+                $level = isset($item['level']) ? trim((string) $item['level']) : null;
+
+                if ($name === '') {
+                    $name = null;
+                }
+
+                if ($level === '') {
+                    $level = null;
+                }
+
+                return $name ? ['name' => $name, 'level' => $level] : null;
+            }
+
+            return null;
+        })
+        ->filter()
+        ->values();
+
+    $hobbyItems = collect($value('hobbies', []))
+        ->map(function ($item) {
+            if (is_string($item)) {
+                return trim($item);
+            }
+
+            if (is_array($item)) {
+                $label = $item['name'] ?? $item['title'] ?? null;
+                return is_string($label) ? trim($label) : null;
+            }
+
+            return null;
+        })
+        ->filter(fn ($item) => is_string($item) && $item !== '')
+        ->values();
+
+    $templateData = [
+        'name' => $fullName,
+        'first_name' => $firstName,
+        'last_name' => $lastName,
+        'headline' => is_string($headline) && trim($headline) !== '' ? trim($headline) : null,
+        'summary' => is_string($summary) && trim($summary) !== '' ? trim($summary) : null,
+        'email' => $email,
+        'phone' => $phone,
+        'website' => $website,
+        'location' => $location,
+        'birthday' => $birthdayFormatted,
+        'contacts' => array_values(array_filter([
+            $email,
+            $phone,
+            $location,
+            $birthdayFormatted,
+            $website,
+        ], fn ($item) => is_string($item) && trim($item) !== '')),
+        'experiences' => $experienceItems->all(),
+        'education' => $educationItems->all(),
+        'skills' => $skillsItems->all(),
+        'languages' => $languageItems->all(),
+        'hobbies' => $hobbyItems->all(),
+        'template' => $value('template'),
+    ];
+@endphp


### PR DESCRIPTION
## Summary
- restyle the dashboard with a gradient hero, actionable cards, and live stats that pull from the user’s CVs
- align auth screens and shared components with updated CreateIt design tokens
- consolidate template data shaping and rebuild each CV template with theme-specific layouts and modal previews

## Testing
- npm run build
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a7affd88833284608e1da1b9f8d0