### PR TITLE
Use TemplateDataBuilder to hydrate CV templates

### DIFF
--- a/app/View/TemplateDataBuilder.php
+++ b/app/View/TemplateDataBuilder.php
@@ -1,27 +1,39 @@
-@php
-        // Helper to safely read nested $cv values
-        $value = fn(string $key, $default = null) => data_get($cv, $key, $default);
+<?php
 
-        // Names
+namespace App\View;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+
+class TemplateDataBuilder
+{
+    /**
+     * Build the template-friendly data representation from a CV payload.
+     */
+    public static function fromCv($cv): array
+    {
+        $value = static function (string $key, $default = null) use ($cv) {
+            return data_get($cv, $key, $default);
+        };
+
         $firstName = $value('first_name');
-        $lastName  = $value('last_name');
-        $fullName  = collect([$firstName, $lastName])
+        $lastName = $value('last_name');
+        $fullName = collect([$firstName, $lastName])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')
             ->map(fn ($item) => trim($item))
             ->implode(' ');
         $fullName = $fullName !== '' ? $fullName : null;
 
-        // Meta
         $headline = $value('headline') ?? $value('title');
-        $summary  = $value('summary')  ?? $value('about');
+        $summary = $value('summary') ?? $value('about');
 
-        // Contacts
-        $email   = $value('email');
-        $phone   = $value('phone');
+        $email = $value('email');
+        $phone = $value('phone');
         $website = $value('website');
 
-        // Location
-        $city    = $value('city');
+        $city = $value('city');
         $country = $value('country');
         $location = collect([$city, $country])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')
@@ -29,49 +41,52 @@
             ->implode(', ');
         $location = $location !== '' ? $location : null;
 
-        // Birthday -> formatted (localized)
         $birthdayRaw = $value('birthday');
         $birthdayFormatted = null;
-        if ($birthdayRaw instanceof \Illuminate\Support\Carbon) {
+        if ($birthdayRaw instanceof Carbon) {
             $birthdayFormatted = $birthdayRaw->translatedFormat('F j, Y');
         } elseif (is_string($birthdayRaw) && trim($birthdayRaw) !== '') {
             try {
-                $birthdayFormatted = \Illuminate\Support\Carbon::parse($birthdayRaw)->translatedFormat('F j, Y');
+                $birthdayFormatted = Carbon::parse($birthdayRaw)->translatedFormat('F j, Y');
             } catch (\Throwable $exception) {
                 $birthdayFormatted = $birthdayRaw;
             }
         }
 
-        // Date formatters
-        $formatMonthYear = function ($val) {
-            if (!is_string($val) || trim($val) === '') return null;
+        $formatMonthYear = static function ($val) {
+            if (!is_string($val) || trim($val) === '') {
+                return null;
+            }
             $val = trim($val);
             try {
                 if (preg_match('/^\d{4}-\d{2}$/', $val)) {
-                    return \Illuminate\Support\Carbon::createFromFormat('Y-m', $val)->translatedFormat('M Y');
+                    return Carbon::createFromFormat('Y-m', $val)->translatedFormat('M Y');
                 }
-                return \Illuminate\Support\Carbon::parse($val)->translatedFormat('M Y');
+
+                return Carbon::parse($val)->translatedFormat('M Y');
             } catch (\Throwable $e) {
                 return $val;
             }
         };
 
-        $formatYear = function ($val) use ($formatMonthYear) {
-            if (!is_string($val) || trim($val) === '') return null;
+        $formatYear = static function ($val) use ($formatMonthYear) {
+            if (!is_string($val) || trim($val) === '') {
+                return null;
+            }
             $val = trim($val);
             try {
                 if (preg_match('/^\d{4}$/', $val)) {
-                    return \Illuminate\Support\Carbon::createFromFormat('Y', $val)->translatedFormat('Y');
+                    return Carbon::createFromFormat('Y', $val)->translatedFormat('Y');
                 }
+
                 return $formatMonthYear($val);
             } catch (\Throwable $e) {
                 return $val;
             }
         };
 
-        // Normalize helper for arrays/collections/json
-        $normaliseCollection = function ($items) {
-            if ($items instanceof \Illuminate\Support\Collection) {
+        $normaliseCollection = static function ($items) {
+            if ($items instanceof Collection) {
                 $items = $items->all();
             }
             if (is_string($items)) {
@@ -82,23 +97,50 @@
                 return collect();
             }
             $collection = collect($items);
-            if ($collection->isEmpty()) return collect();
-            if ($collection->isAssoc()) {
+            if ($collection->isEmpty()) {
+                return collect();
+            }
+            if (Arr::isAssoc($collection->all())) {
                 $collection = collect([$collection->all()]);
             }
+
             return $collection
                 ->map(function ($item) {
-                    if ($item instanceof \Illuminate\Support\Collection) return $item->toArray();
-                    if (is_object($item)) return collect(get_object_vars($item))->toArray();
+                    if ($item instanceof Collection) {
+                        return $item->toArray();
+                    }
+                    if (is_object($item)) {
+                        return collect(get_object_vars($item))->toArray();
+                    }
+
                     return is_array($item) ? $item : [];
                 })
-                ->filter(fn ($item) => !empty(array_filter($item, fn ($v) => is_array($v) ? !empty($v) : trim((string)$v) !== '')))
+                ->filter(function ($item) {
+                    if (!is_array($item)) {
+                        return false;
+                    }
+
+                    foreach ($item as $value) {
+                        if (is_array($value)) {
+                            if (!empty($value)) {
+                                return true;
+                            }
+
+                            continue;
+                        }
+
+                        if (trim((string) $value) !== '') {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                })
                 ->values();
         };
 
-        // Experience
         $experienceItems = $normaliseCollection($value('work_experience', $value('experience', [])))->map(function ($exp) use ($formatMonthYear) {
-            $role    = $exp['position'] ?? $exp['role'] ?? null;
+            $role = $exp['position'] ?? $exp['role'] ?? null;
             $company = $exp['company'] ?? null;
             $loc = collect([$exp['city'] ?? null, $exp['country'] ?? null])
                 ->filter(fn ($i) => is_string($i) && trim($i) !== '')
@@ -106,35 +148,34 @@
                 ->implode(', ');
             $loc = $loc !== '' ? $loc : null;
 
-            $fromRaw   = $exp['from'] ?? null;
-            $toRaw     = $exp['to'] ?? null;
-            $from      = $formatMonthYear($fromRaw);
+            $fromRaw = $exp['from'] ?? null;
+            $toRaw = $exp['to'] ?? null;
+            $from = $formatMonthYear($fromRaw);
             $isCurrent = !empty($exp['currently']);
-            $to        = $isCurrent ? __('Present') : $formatMonthYear($toRaw);
-            $period    = collect([$from, $to])->filter()->implode(' – ');
+            $to = $isCurrent ? __('Present') : $formatMonthYear($toRaw);
+            $period = collect([$from, $to])->filter()->implode(' – ');
 
-            $summary   = $exp['achievements'] ?? $exp['description'] ?? null;
+            $summaryValue = $exp['achievements'] ?? $exp['description'] ?? null;
 
             return [
-                'role'       => $role,
-                'company'    => $company,
-                'location'   => $loc,
-                'from'       => $from,
-                'to'         => $to,
-                'from_raw'   => $fromRaw,
-                'to_raw'     => $toRaw,
+                'role' => $role,
+                'company' => $company,
+                'location' => $loc,
+                'from' => $from,
+                'to' => $to,
+                'from_raw' => $fromRaw,
+                'to_raw' => $toRaw,
                 'is_current' => $isCurrent,
-                'period'     => $period !== '' ? $period : null,
-                'summary'    => is_string($summary) && trim($summary) !== '' ? trim($summary) : null,
+                'period' => $period !== '' ? $period : null,
+                'summary' => is_string($summaryValue) && trim($summaryValue) !== '' ? trim($summaryValue) : null,
             ];
         })->filter(fn ($i) => ($i['role'] ?? null) || ($i['company'] ?? null) || ($i['summary'] ?? null))
-          ->values();
+            ->values();
 
-        // Education
         $educationItems = $normaliseCollection($value('education', []))->map(function ($edu) use ($formatYear) {
             $institution = $edu['institution'] ?? $edu['school'] ?? null;
-            $degree      = $edu['degree'] ?? null;
-            $field       = $edu['field'] ?? null;
+            $degree = $edu['degree'] ?? null;
+            $field = $edu['field'] ?? null;
 
             $loc = collect([$edu['city'] ?? null, $edu['country'] ?? null])
                 ->filter(fn ($i) => is_string($i) && trim($i) !== '')
@@ -142,73 +183,83 @@
                 ->implode(', ');
             $loc = $loc !== '' ? $loc : null;
 
-            $start  = $formatYear($edu['start_year'] ?? $edu['from'] ?? null);
-            $end    = $formatYear($edu['end_year']   ?? $edu['to']   ?? null);
+            $start = $formatYear($edu['start_year'] ?? $edu['from'] ?? null);
+            $end = $formatYear($edu['end_year'] ?? $edu['to'] ?? null);
             $period = collect([$start, $end])->filter()->implode(' – ');
 
             return [
                 'institution' => $institution,
-                'degree'      => $degree,
-                'field'       => $field,
-                'location'    => $loc,
-                'start'       => $start,
-                'end'         => $end,
-                'period'      => $period !== '' ? $period : null,
+                'degree' => $degree,
+                'field' => $field,
+                'location' => $loc,
+                'start' => $start,
+                'end' => $end,
+                'period' => $period !== '' ? $period : null,
             ];
         })->filter(fn ($i) => ($i['institution'] ?? null) || ($i['degree'] ?? null) || ($i['field'] ?? null))
-          ->values();
+            ->values();
 
-        // Skills (accepts array of strings or objects with name/title)
         $skillsItems = collect($value('skills', []))
             ->map(function ($item) {
-                if (is_string($item)) return trim($item);
+                if (is_string($item)) {
+                    return trim($item);
+                }
                 if (is_array($item)) {
                     $label = $item['name'] ?? $item['title'] ?? null;
+
                     return is_string($label) ? trim($label) : null;
                 }
+
                 return null;
             })
             ->filter(fn ($s) => is_string($s) && $s !== '')
             ->values();
 
-        // Languages (string or {name, level})
         $languageItems = collect($value('languages', []))
             ->map(function ($item) {
                 if (is_string($item)) {
                     return ['name' => trim($item), 'level' => null];
                 }
                 if (is_array($item)) {
-                    $name  = isset($item['name'])  ? trim((string) $item['name'])  : null;
+                    $name = isset($item['name']) ? trim((string) $item['name']) : null;
                     $level = isset($item['level']) ? trim((string) $item['level']) : null;
-                    if ($name === '')  $name  = null;
-                    if ($level === '') $level = null;
+                    if ($name === '') {
+                        $name = null;
+                    }
+                    if ($level === '') {
+                        $level = null;
+                    }
+
                     return $name ? ['name' => $name, 'level' => $level] : null;
                 }
+
                 return null;
             })
             ->filter()
             ->values();
 
-        // Hobbies (string or {name/title})
         $hobbyItems = collect($value('hobbies', []))
             ->map(function ($item) {
-                if (is_string($item)) return trim($item);
+                if (is_string($item)) {
+                    return trim($item);
+                }
                 if (is_array($item)) {
                     $label = $item['name'] ?? $item['title'] ?? null;
+
                     return is_string($label) ? trim($label) : null;
                 }
+
                 return null;
             })
             ->filter(fn ($h) => is_string($h) && $h !== '')
             ->values();
 
-        // Profile image (url or storage path)
         $profileImage = $value('profile_image');
         if (is_string($profileImage) && trim($profileImage) !== '') {
             $profileImage = trim($profileImage);
             if (!filter_var($profileImage, FILTER_VALIDATE_URL)) {
                 try {
-                    $profileImage = \Illuminate\Support\Facades\Storage::disk('public')->url($profileImage);
+                    $profileImage = Storage::disk('public')->url($profileImage);
                 } catch (\Throwable $e) {
                     $profileImage = null;
                 }
@@ -217,33 +268,33 @@
             $profileImage = null;
         }
 
-        // Final data bag for the view
         $templateData = [
-            'name'         => $fullName,
-            'first_name'   => $firstName,
-            'last_name'    => $lastName,
-            'headline'     => is_string($headline) && trim($headline) !== '' ? trim($headline) : null,
-            'summary'      => is_string($summary)  && trim($summary)  !== '' ? trim($summary)  : null,
-            'email'        => $email,
-            'phone'        => $phone,
-            'website'      => $website,
-            'location'     => $location,
-            'birthday'     => $birthdayFormatted,
-            'contacts'     => array_values(array_filter([
+            'name' => $fullName,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            'headline' => is_string($headline) && trim($headline) !== '' ? trim($headline) : null,
+            'summary' => is_string($summary) && trim($summary) !== '' ? trim($summary) : null,
+            'email' => $email,
+            'phone' => $phone,
+            'website' => $website,
+            'location' => $location,
+            'birthday' => $birthdayFormatted,
+            'contacts' => array_values(array_filter([
                 $email,
                 $phone,
                 $location,
                 $birthdayFormatted,
                 $website,
             ], fn ($i) => is_string($i) && trim($i) !== '')),
-            'profile_image'=> $profileImage,
-            'experiences'  => $experienceItems->all(),
-            'education'    => $educationItems->all(),
-            'skills'       => $skillsItems->all(),
-            'languages'    => $languageItems->all(),
-            'hobbies'      => $hobbyItems->all(),
-            'template'     => $value('template'),
+            'profile_image' => $profileImage,
+            'experiences' => $experienceItems->all(),
+            'education' => $educationItems->all(),
+            'skills' => $skillsItems->all(),
+            'languages' => $languageItems->all(),
+            'hobbies' => $hobbyItems->all(),
+            'template' => $value('template'),
         ];
 
-        $data = $templateData; // alias used below
-    @endphp
+        return $templateData;
+    }
+}

--- a/resources/views/templates/classic.blade.php
+++ b/resources/views/templates/classic.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/classic.css') }}">
 </head>
 <body class="classic-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
     @endphp
 

--- a/resources/views/templates/corporate.blade.php
+++ b/resources/views/templates/corporate.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/corporate.css') }}">
 </head>
 <body class="corporate-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/creative.blade.php
+++ b/resources/views/templates/creative.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/creative.css') }}">
 </head>
 <body class="creative-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/darkmode.blade.php
+++ b/resources/views/templates/darkmode.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/darkmode.css') }}">
 </head>
 <body class="darkmode-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/elegant.blade.php
+++ b/resources/views/templates/elegant.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/elegant.css') }}">
 </head>
 <body class="elegant-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/futuristic.blade.php
+++ b/resources/views/templates/futuristic.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/futuristic.css') }}">
 </head>
 <body class="futuristic-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/gradient.blade.php
+++ b/resources/views/templates/gradient.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/gradient.css') }}">
 </head>
 <body class="gradient-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/minimal.blade.php
+++ b/resources/views/templates/minimal.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/minimal.css') }}">
 </head>
 <body class="minimal-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/modern.blade.php
+++ b/resources/views/templates/modern.blade.php
@@ -6,9 +6,8 @@
     <link rel="stylesheet" href="{{ asset('templates/css/modern.css') }}">
 </head>
 <body class="modern-template">
-    @include('templates.partials.base-data-helper', ['cv' => $cv])
-
     @php
+        $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
         $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
             ->filter(fn ($item) => is_string($item) && trim($item) !== '')

--- a/resources/views/templates/partials/base-data.blade.php
+++ b/resources/views/templates/partials/base-data.blade.php
@@ -1,2 +1,5 @@
-{{-- Shared template data helper include --}}
-@include('templates.partials.base-data-helper', ['cv' => $cv ?? null])
+{{-- Shared template data helper. Prefer using the TemplateDataBuilder directly. --}}
+@php
+    $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
+    $data = $templateData;
+@endphp


### PR DESCRIPTION
## Summary
- move the CV data normalisation logic into `App\View\TemplateDataBuilder`
- update each resume template to pull its `$templateData` from the new builder and drop the Blade helper include
- refresh the shared `base-data` partial to call the builder directly

## Testing
- php artisan test *(fails: missing `vendor/autoload.php` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d52bd82a6483328f8028825aefeb32