### PR TITLE
Fix unmatched parentheses in CV preview helpers

### DIFF
--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -130,7 +130,7 @@
                     }
 
                     return is_string($skill) ? trim($skill) : null;
-                }, $skills), fn ($skill) => is_string($skill) && $skill !== '')));
+                }, $skills), fn ($skill) => is_string($skill) && $skill !== ''));
 
                 $languages = $cvData['languages'] ?? [];
                 if ($languages && !is_array($languages)) {
@@ -156,7 +156,7 @@
                     }
 
                     return ['name' => $name, 'level' => $level !== '' ? $level : null];
-                }, $languages), fn ($language) => is_array($language) && ($language['name'] ?? null)));
+                }, $languages), fn ($language) => is_array($language) && ($language['name'] ?? null));
 
                 $headline = is_string($cvData['headline'] ?? null) ? trim($cvData['headline']) : null;
                 $summaryText = is_string($cvData['summary'] ?? null) ? trim($cvData['summary']) : null;


### PR DESCRIPTION
## Summary
- fix the validation helpers that normalise skills and languages data in the CV preview
- ensure the helper pipelines close correctly so the preview page renders

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5304772dc8332a5d6c0d67ace18e4