### PR TITLE
Redesign resume templates for distinct layouts

### DIFF
--- a/public/templates/css/classic.css
+++ b/public/templates/css/classic.css
@@ -39,6 +39,33 @@
     background: linear-gradient(135deg, rgba(15, 23, 42, 0.04), rgba(148, 163, 184, 0.12));
 }
 
+.classic-template .identity {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+}
+
+.classic-template .portrait {
+    width: 88px;
+    height: 88px;
+    border-radius: 20px;
+    background: rgba(15, 23, 42, 0.05);
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 30px;
+    font-weight: 600;
+    color: var(--slate-500);
+    overflow: hidden;
+}
+
+.classic-template .portrait img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
 .classic-template header h1 {
     margin: 0;
     font-size: 32px;

--- a/public/templates/css/corporate.css
+++ b/public/templates/css/corporate.css
@@ -1,10 +1,10 @@
 :root {
-    --corporate-navy: #0f172a;
-    --corporate-steel: #1e293b;
-    --corporate-gray: #475569;
-    --corporate-silver: #cbd5f5;
+    --corporate-navy: #0b1f33;
+    --corporate-steel: #2f3e58;
+    --corporate-muted: #5b6b87;
     --corporate-border: #e2e8f0;
-    --corporate-background: #f8fafc;
+    --corporate-highlight: #f97316;
+    --corporate-soft: #f8fafc;
 }
 
 * {
@@ -13,36 +13,35 @@
 
 body.corporate-template {
     margin: 0;
-    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: var(--corporate-background);
+    font-family: "Source Sans Pro", "Inter", sans-serif;
+    background: linear-gradient(135deg, rgba(15, 52, 96, 0.12), rgba(241, 245, 249, 0.9));
     color: var(--corporate-navy);
-    font-size: 14px;
-    line-height: 1.6;
-    padding: 56px;
+    font-size: 13px;
+    line-height: 1.7;
+    padding: 60px;
 }
 
-.corporate-page {
-    max-width: 980px;
+.corporate-wrapper {
+    max-width: 1024px;
     margin: 0 auto;
     background: #fff;
     border-radius: 32px;
-    border: 1px solid var(--corporate-border);
-    box-shadow: 0 36px 70px rgba(15, 23, 42, 0.12);
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
+    box-shadow: 0 40px 80px rgba(15, 23, 42, 0.14);
+    border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.corporate-header {
-    padding: 44px 56px;
-    background: linear-gradient(130deg, rgba(15, 23, 42, 0.1), rgba(15, 23, 42, 0.04));
+.corporate-topbar {
+    padding: 48px 56px;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(47, 62, 88, 0.75));
     display: flex;
     justify-content: space-between;
+    gap: 32px;
     align-items: center;
-    gap: 24px;
+    color: #f8fafc;
 }
 
-.corporate-header__identity {
+.corporate-brand {
     display: flex;
     align-items: center;
     gap: 24px;
@@ -52,14 +51,15 @@ body.corporate-template {
     width: 92px;
     height: 92px;
     border-radius: 26px;
-    background: rgba(15, 23, 42, 0.08);
-    border: 1px solid rgba(15, 23, 42, 0.2);
+    background: rgba(248, 250, 252, 0.08);
+    border: 2px solid rgba(248, 250, 252, 0.35);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 30px;
+    font-size: 34px;
     font-weight: 600;
-    color: var(--corporate-steel);
+    text-transform: uppercase;
+    color: #f8fafc;
     overflow: hidden;
 }
 
@@ -69,118 +69,41 @@ body.corporate-template {
     object-fit: cover;
 }
 
-.corporate-header__identity h1 {
-    margin: 0;
-    font-size: 30px;
-}
-
-.corporate-header__identity p {
-    margin: 6px 0 0;
-    color: var(--corporate-gray);
-    font-size: 14px;
-}
-
-.corporate-header__details {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 10px;
-    color: var(--corporate-gray);
-    font-size: 12px;
-}
-
 .corporate-badge {
+    margin: 0;
     text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 10px;
-    color: rgba(15, 23, 42, 0.6);
+    letter-spacing: 0.38em;
+    font-size: 11px;
+    color: rgba(248, 250, 252, 0.68);
 }
 
-.corporate-grid {
-    display: grid;
-    grid-template-columns: 300px 1fr;
-    gap: 36px;
-    padding: 44px 56px 56px;
+.corporate-topbar h1 {
+    margin: 10px 0 0;
+    font-size: 36px;
 }
 
-.corporate-sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
+.corporate-topbar p {
+    margin: 8px 0 0;
+    font-size: 15px;
+    color: rgba(248, 250, 252, 0.78);
 }
 
-.corporate-card {
-    border: 1px solid var(--corporate-border);
-    border-radius: 24px;
-    padding: 22px;
-    background: rgba(248, 250, 252, 0.9);
-}
-
-.corporate-card h2,
-.corporate-section__head h2 {
-    margin: 0 0 12px;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.32em;
-    color: var(--corporate-gray);
-}
-
-.corporate-card p {
-    margin: 0;
-    font-size: 13px;
-    color: var(--corporate-gray);
-}
-
-.corporate-card ul {
-    list-style: none;
+.corporate-contact {
     margin: 0;
     padding: 0;
-    display: grid;
-    gap: 8px;
-    font-size: 12px;
-    color: var(--corporate-gray);
-}
-
-.corporate-pill-list {
     list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    font-size: 12px;
-}
-
-.corporate-pill-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(15, 23, 42, 0.08);
-    color: var(--corporate-steel);
-}
-
-.corporate-language {
-    list-style: none;
-    margin: 0;
-    padding: 0;
     display: grid;
     gap: 6px;
     font-size: 12px;
-    color: var(--corporate-gray);
+    color: rgba(248, 250, 252, 0.75);
+    text-align: right;
 }
 
-.corporate-language li {
-    display: flex;
-    justify-content: space-between;
-}
-
-.corporate-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+.corporate-body {
     display: grid;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--corporate-gray);
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 40px;
+    padding: 48px 56px;
 }
 
 .corporate-main {
@@ -192,66 +115,104 @@ body.corporate-template {
 .corporate-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
-}
-
-.corporate-section__head {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 24px;
-}
-
-.corporate-section__head p {
-    margin: 0;
-    font-size: 12px;
-    color: var(--corporate-gray);
-}
-
-.corporate-experience {
-    display: grid;
     gap: 20px;
 }
 
-.corporate-experience__item {
-    border-bottom: 1px solid var(--corporate-border);
-    padding-bottom: 18px;
-}
-
-.corporate-experience__item:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
-.corporate-experience__meta {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    gap: 16px;
-}
-
-.corporate-experience__meta h3 {
+.corporate-section header h2,
+.corporate-section--summary h2 {
     margin: 0;
-    font-size: 18px;
+    font-size: 22px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
     color: var(--corporate-steel);
 }
 
-.corporate-experience__meta span {
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: var(--corporate-gray);
+.corporate-section header p,
+.corporate-section--summary p {
+    margin: 0;
+    color: var(--corporate-muted);
 }
 
-.corporate-experience__company {
+.corporate-section--summary {
+    background: var(--corporate-soft);
+    padding: 24px;
+    border-radius: 24px;
+    border: 1px solid var(--corporate-border);
+}
+
+.corporate-timeline {
+    position: relative;
+    display: grid;
+    gap: 24px;
+    padding-left: 28px;
+}
+
+.corporate-timeline::before {
+    content: "";
+    position: absolute;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, rgba(15, 23, 42, 0.15), rgba(15, 23, 42, 0.05));
+}
+
+.corporate-timeline article {
+    position: relative;
+    display: flex;
+    gap: 18px;
+}
+
+.corporate-timeline__marker {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    border: 4px solid var(--corporate-highlight);
+    position: absolute;
+    left: -28px;
+    top: 4px;
+}
+
+.corporate-timeline__body {
+    padding: 20px 24px;
+    border-radius: 20px;
+    border: 1px solid var(--corporate-border);
+    background: #fff;
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.corporate-timeline__head {
+    display: flex;
+    justify-content: space-between;
+    gap: 18px;
+    align-items: flex-start;
+}
+
+.corporate-timeline__head h3 {
+    margin: 0;
+    font-size: 18px;
+    color: var(--corporate-navy);
+}
+
+.corporate-timeline__head p {
     margin: 6px 0 0;
-    font-size: 12px;
-    color: var(--corporate-gray);
+    color: var(--corporate-muted);
+    font-size: 13px;
 }
 
-.corporate-experience__summary {
-    margin: 10px 0 0;
-    font-size: 13px;
+.corporate-timeline__head span {
+    font-size: 12px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--corporate-muted);
+}
+
+.corporate-timeline__summary {
+    margin: 0;
     color: var(--corporate-steel);
 }
 
@@ -260,35 +221,94 @@ body.corporate-template {
     gap: 18px;
 }
 
-.corporate-education__title {
+.corporate-education article {
+    border: 1px solid var(--corporate-border);
+    border-radius: 20px;
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.corporate-education__head {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    gap: 16px;
+    gap: 12px;
 }
 
-.corporate-education__title h3 {
+.corporate-education__head h3 {
     margin: 0;
     font-size: 16px;
+    color: var(--corporate-navy);
+}
+
+.corporate-education__head span {
+    font-size: 12px;
+    color: var(--corporate-muted);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+}
+
+.corporate-education p {
+    margin: 0;
     color: var(--corporate-steel);
 }
 
-.corporate-education__title span {
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.18em;
-    color: var(--corporate-gray);
+.corporate-education__location {
+    color: var(--corporate-muted);
 }
 
-.corporate-education__institution {
-    margin: 6px 0 0;
-    font-size: 13px;
-    color: var(--corporate-gray);
-}
-
-.corporate-education__meta {
+.corporate-aside {
     display: flex;
-    gap: 16px;
-    font-size: 12px;
-    color: var(--corporate-gray);
+    flex-direction: column;
+    gap: 28px;
+}
+
+.corporate-aside section {
+    border: 1px solid var(--corporate-border);
+    border-radius: 20px;
+    padding: 24px;
+    background: var(--corporate-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.corporate-aside h2 {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    font-size: 11px;
+    color: var(--corporate-muted);
+}
+
+.corporate-aside ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+    color: var(--corporate-steel);
+    font-size: 13px;
+}
+
+.corporate-aside li {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+@media (max-width: 860px) {
+    body.corporate-template {
+        padding: 32px;
+    }
+
+    .corporate-body {
+        grid-template-columns: 1fr;
+    }
+
+    .corporate-contact {
+        text-align: left;
+    }
 }

--- a/public/templates/css/creative.css
+++ b/public/templates/css/creative.css
@@ -1,11 +1,11 @@
 :root {
-    --creative-pink: #ec4899;
-    --creative-purple: #a855f7;
-    --creative-slate-900: #111827;
-    --creative-slate-700: #374151;
-    --creative-slate-500: #6b7280;
-    --creative-slate-200: #e5e7eb;
-    --creative-slate-100: #f3f4f6;
+    --creative-navy: #0f172a;
+    --creative-violet: #7c3aed;
+    --creative-pink: #f472b6;
+    --creative-amber: #fbbf24;
+    --creative-sky: #38bdf8;
+    --creative-surface: #0b1220;
+    --creative-muted: rgba(226, 232, 240, 0.78);
 }
 
 * {
@@ -14,290 +14,289 @@
 
 body.creative-template {
     margin: 0;
-    font-family: 'Sofia Pro', 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: radial-gradient(circle at top left, rgba(236, 72, 153, 0.12), transparent 50%),
-        radial-gradient(circle at top right, rgba(168, 85, 247, 0.12), transparent 50%),
-        #fdf2f8;
-    color: var(--creative-slate-900);
-    font-size: 14px;
-    line-height: 1.6;
-    padding: 48px;
+    font-family: "Manrope", "Inter", sans-serif;
+    background: radial-gradient(circle at top left, rgba(124, 58, 237, 0.22), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.18), transparent 50%), #020617;
+    color: #f8fafc;
+    font-size: 13px;
+    line-height: 1.7;
+    padding: 56px;
 }
 
-.creative-page {
-    background: rgba(255, 255, 255, 0.94);
-    border-radius: 36px;
-    border: 1px solid rgba(236, 72, 153, 0.15);
-    box-shadow: 0 45px 90px rgba(236, 72, 153, 0.18);
+.creative-canvas {
+    max-width: 960px;
+    margin: 0 auto;
+    border-radius: 32px;
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
+    background: rgba(2, 6, 23, 0.92);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 50px 90px rgba(15, 23, 42, 0.45);
 }
 
-.creative-hero {
-    padding: 48px;
-    background: linear-gradient(140deg, rgba(236, 72, 153, 0.18), rgba(168, 85, 247, 0.18));
-    display: grid;
-    grid-template-columns: auto 1fr auto;
+.creative-banner {
+    padding: 48px 56px;
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.5), rgba(244, 114, 182, 0.35));
+    display: flex;
+    justify-content: space-between;
+    gap: 36px;
+    align-items: center;
+}
+
+.creative-nameplate {
+    display: flex;
+    align-items: center;
     gap: 24px;
-    align-items: center;
 }
 
-.creative-hero__badge {
-    text-transform: uppercase;
-    letter-spacing: 0.38em;
-    font-size: 10px;
-    color: rgba(17, 24, 39, 0.55);
-}
-
-.creative-hero__profile {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-}
-
-.creative-hero__avatar {
-    width: 88px;
-    height: 88px;
-    border-radius: 24px;
-    background: linear-gradient(135deg, rgba(236, 72, 153, 0.5), rgba(168, 85, 247, 0.5));
-    box-shadow: 0 16px 28px rgba(236, 72, 153, 0.35);
+.creative-avatar {
+    width: 96px;
+    height: 96px;
+    border-radius: 28px;
+    border: 3px solid rgba(248, 250, 252, 0.45);
+    background: rgba(15, 23, 42, 0.24);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-weight: 600;
-    font-size: 30px;
-    color: #fff;
+    font-size: 36px;
+    font-weight: 700;
+    color: #f8fafc;
     overflow: hidden;
+    text-transform: uppercase;
 }
 
-.creative-hero__avatar img {
+.creative-avatar img {
     width: 100%;
     height: 100%;
     object-fit: cover;
 }
 
-.creative-hero__profile h1 {
+.creative-badge {
     margin: 0;
-    font-size: 30px;
-    letter-spacing: 0.01em;
-}
-
-.creative-hero__profile p {
-    margin: 6px 0 0;
-    color: var(--creative-slate-500);
-}
-
-.creative-hero__location {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.28em;
-    color: rgba(17, 24, 39, 0.55);
-}
-
-.creative-content {
-    display: grid;
-    grid-template-columns: 320px 1fr;
-    gap: 32px;
-    padding: 48px;
-}
-
-.creative-aside {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.creative-card {
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 28px;
-    padding: 24px;
-    border: 1px solid rgba(236, 72, 153, 0.12);
-    box-shadow: 0 18px 36px rgba(17, 24, 39, 0.06);
-}
-
-.creative-card--accent {
-    background: linear-gradient(160deg, rgba(236, 72, 153, 0.18), rgba(244, 114, 182, 0.2));
-    border: 1px solid rgba(236, 72, 153, 0.18);
-    color: var(--creative-slate-900);
-}
-
-.creative-card h2 {
-    margin: 0 0 12px;
-    font-size: 13px;
-    text-transform: uppercase;
     letter-spacing: 0.32em;
-    color: var(--creative-slate-500);
-}
-
-.creative-card--accent h2 {
-    color: rgba(17, 24, 39, 0.6);
-}
-
-.creative-card p {
-    margin: 0;
-    font-size: 13px;
-    color: var(--creative-slate-700);
-}
-
-.creative-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 10px;
-    font-size: 12px;
-    color: var(--creative-slate-600);
-}
-
-.creative-list--condensed {
-    gap: 6px;
-}
-
-.creative-list__primary {
-    font-weight: 600;
-    color: var(--creative-slate-900);
-}
-
-.creative-list__secondary {
-    margin-left: 6px;
-    color: var(--creative-slate-500);
-    font-size: 11px;
     text-transform: uppercase;
+    font-size: 11px;
+    color: rgba(248, 250, 252, 0.72);
 }
 
-.creative-tag-list {
-    list-style: none;
+.creative-banner h1 {
+    margin: 8px 0 0;
+    font-size: 38px;
+    letter-spacing: 0.03em;
+}
+
+.creative-headline {
+    margin: 8px 0 0;
+    font-size: 16px;
+    color: rgba(248, 250, 252, 0.8);
+}
+
+.creative-contact-list {
     margin: 0;
     padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-}
-
-.creative-tag-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(236, 72, 153, 0.16);
+    list-style: none;
+    display: grid;
+    gap: 6px;
     font-size: 12px;
-    color: var(--creative-slate-900);
+    color: rgba(248, 250, 252, 0.75);
+    text-align: right;
 }
 
-.creative-tag-list--soft li {
-    background: rgba(168, 85, 247, 0.12);
-}
-
-.creative-main {
+.creative-body {
+    padding: 48px 56px 64px;
     display: flex;
     flex-direction: column;
     gap: 40px;
 }
 
-.creative-section-head h2 {
-    margin: 0;
-    font-size: 20px;
-    color: var(--creative-slate-900);
-}
-
-.creative-section-head p {
-    margin: 8px 0 0;
-    font-size: 13px;
-    color: var(--creative-slate-500);
-}
-
-.creative-experience-grid {
+.creative-intro {
     display: grid;
     gap: 24px;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.creative-experience-card {
-    background: rgba(255, 255, 255, 0.95);
+.creative-panel {
     border-radius: 28px;
-    padding: 24px;
-    border: 1px solid rgba(168, 85, 247, 0.18);
-    box-shadow: 0 20px 34px rgba(168, 85, 247, 0.16);
+    padding: 28px;
+    background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(30, 41, 59, 0.6));
+    border: 1px solid rgba(148, 163, 184, 0.25);
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 14px;
 }
 
-.creative-experience-card__header {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    gap: 16px;
-    align-items: start;
-}
-
-.creative-experience-card__header h3 {
+.creative-panel h2 {
     margin: 0;
-    font-size: 17px;
-}
-
-.creative-experience-card__header p {
-    margin: 6px 0 0;
-    font-size: 12px;
-    color: var(--creative-slate-500);
-}
-
-.creative-experience-card__body {
-    margin: 0;
-    font-size: 13px;
-    color: var(--creative-slate-700);
-}
-
-.creative-dot {
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, var(--creative-pink), var(--creative-purple));
-    box-shadow: 0 8px 18px rgba(236, 72, 153, 0.3);
-}
-
-.creative-chip {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(17, 24, 39, 0.05);
-    font-size: 11px;
     text-transform: uppercase;
-    letter-spacing: 0.18em;
-    color: var(--creative-slate-500);
+    letter-spacing: 0.32em;
+    font-size: 11px;
+    color: rgba(248, 250, 252, 0.7);
+}
+
+.creative-panel p {
+    margin: 0;
+    color: rgba(248, 250, 252, 0.88);
+    font-size: 14px;
+}
+
+.creative-panel ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 10px;
+    font-size: 13px;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.creative-panel--skills ul {
+    grid-auto-flow: dense;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    display: grid;
+    gap: 10px;
+}
+
+.creative-panel--skills li {
+    padding: 8px 14px;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.15);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+    text-align: center;
+}
+
+.creative-panel--extra {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 18px;
+}
+
+.creative-panel--extra div {
+    display: grid;
+    gap: 10px;
+}
+
+.creative-panel--extra li {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.creative-section {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.creative-section header h2 {
+    margin: 0;
+    font-size: 24px;
+    letter-spacing: 0.08em;
+}
+
+.creative-section header p {
+    margin: 6px 0 0;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.creative-section--experience .creative-experience {
+    display: grid;
+    gap: 24px;
+}
+
+.creative-experience article {
+    border-radius: 24px;
+    padding: 26px;
+    background: linear-gradient(135deg, rgba(124, 58, 237, 0.18), rgba(8, 47, 73, 0.6));
+    border: 1px solid rgba(124, 58, 237, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    position: relative;
+    overflow: hidden;
+}
+
+.creative-experience__meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.creative-experience__meta h3 {
+    margin: 0;
+    font-size: 20px;
+}
+
+.creative-experience__meta p {
+    margin: 8px 0 0;
+    color: rgba(226, 232, 240, 0.75);
+}
+
+.creative-experience__meta span {
+    font-size: 12px;
+    color: rgba(226, 232, 240, 0.65);
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+}
+
+.creative-experience__summary {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.9);
+    font-size: 14px;
 }
 
 .creative-education {
     display: grid;
-    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 24px;
 }
 
-.creative-education__item {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 20px;
-}
-
-.creative-education__timeline {
-    width: 14px;
-    border-radius: 12px;
-    background: linear-gradient(180deg, rgba(236, 72, 153, 0.4), rgba(168, 85, 247, 0.4));
-}
-
-.creative-education__content h3 {
-    margin: 0;
-    font-size: 17px;
-}
-
-.creative-education__meta {
-    margin: 6px 0 0;
-    font-size: 12px;
-    color: var(--creative-slate-500);
-}
-
-.creative-education__footer {
-    margin-top: 12px;
+.creative-education article {
+    padding: 22px;
+    border-radius: 20px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    background: rgba(15, 23, 42, 0.65);
     display: flex;
-    gap: 16px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: rgba(17, 24, 39, 0.5);
+    flex-direction: column;
+    gap: 10px;
+}
+
+.creative-education__head {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: baseline;
+}
+
+.creative-education__head h3 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.creative-education__head span {
+    font-size: 12px;
+    color: rgba(226, 232, 240, 0.65);
+}
+
+.creative-education p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.creative-education__location {
+    color: rgba(148, 163, 184, 0.75);
+}
+
+@media (max-width: 720px) {
+    body.creative-template {
+        padding: 24px;
+    }
+
+    .creative-banner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .creative-contact-list {
+        text-align: left;
+    }
 }

--- a/public/templates/css/darkmode.css
+++ b/public/templates/css/darkmode.css
@@ -1,10 +1,10 @@
 :root {
-    --darkmode-bg: #0b1120;
-    --darkmode-panel: #111c33;
-    --darkmode-border: #1f2a44;
-    --darkmode-text: #e2e8f0;
-    --darkmode-muted: #94a3b8;
-    --darkmode-accent: #38bdf8;
+    --darkmode-bg: #020617;
+    --darkmode-surface: rgba(15, 23, 42, 0.85);
+    --darkmode-border: rgba(148, 163, 184, 0.24);
+    --darkmode-accent: #22d3ee;
+    --darkmode-accent-2: #a855f7;
+    --darkmode-muted: rgba(203, 213, 225, 0.72);
 }
 
 * {
@@ -13,33 +13,33 @@
 
 body.darkmode-template {
     margin: 0;
-    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.18), transparent 55%),
-        radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.18), transparent 55%),
+    font-family: "Space Grotesk", "Inter", sans-serif;
+    background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.16), transparent 55%),
+        radial-gradient(circle at bottom right, rgba(168, 85, 247, 0.16), transparent 55%),
         var(--darkmode-bg);
-    color: var(--darkmode-text);
-    font-size: 14px;
+    color: #f8fafc;
+    font-size: 13px;
     line-height: 1.7;
-    padding: 56px;
+    padding: 60px;
 }
 
-.darkmode-page {
-    max-width: 960px;
+.darkmode-shell {
+    max-width: 1000px;
     margin: 0 auto;
-    background: rgba(15, 23, 42, 0.9);
-    border-radius: 32px;
-    border: 1px solid var(--darkmode-border);
-    box-shadow: 0 40px 80px rgba(2, 6, 23, 0.6);
+    border-radius: 36px;
     overflow: hidden;
+    background: var(--darkmode-surface);
+    border: 1px solid var(--darkmode-border);
+    box-shadow: 0 50px 80px rgba(15, 23, 42, 0.5);
 }
 
-.darkmode-hero {
+.darkmode-header {
     padding: 48px 56px;
+    background: linear-gradient(130deg, rgba(34, 211, 238, 0.28), rgba(168, 85, 247, 0.32));
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 24px;
-    background: linear-gradient(120deg, rgba(56, 189, 248, 0.18), rgba(14, 165, 233, 0.1));
+    gap: 32px;
 }
 
 .darkmode-identity {
@@ -52,14 +52,15 @@ body.darkmode-template {
     width: 90px;
     height: 90px;
     border-radius: 28px;
-    background: rgba(2, 6, 23, 0.5);
-    border: 1px solid rgba(56, 189, 248, 0.3);
+    background: rgba(2, 6, 23, 0.55);
+    border: 2px solid rgba(248, 250, 252, 0.4);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 30px;
-    font-weight: 600;
-    color: var(--darkmode-accent);
+    font-size: 32px;
+    font-weight: 700;
+    color: #f8fafc;
+    text-transform: uppercase;
     overflow: hidden;
 }
 
@@ -70,217 +71,234 @@ body.darkmode-template {
 }
 
 .darkmode-badge {
+    margin: 0;
     text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 10px;
-    color: rgba(148, 163, 184, 0.7);
+    letter-spacing: 0.4em;
+    font-size: 11px;
+    color: rgba(248, 250, 252, 0.7);
 }
 
-.darkmode-hero h1 {
-    margin: 8px 0 0;
-    font-size: 32px;
-    letter-spacing: 0.02em;
+.darkmode-header h1 {
+    margin: 10px 0 0;
+    font-size: 36px;
 }
 
 .darkmode-headline {
-    margin: 6px 0 0;
-    color: var(--darkmode-muted);
-    font-size: 14px;
+    margin: 8px 0 0;
+    font-size: 15px;
+    color: rgba(248, 250, 252, 0.78);
 }
 
-.darkmode-location {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.28em;
-    color: rgba(148, 163, 184, 0.7);
-}
-
-.darkmode-layout {
+.darkmode-contact {
+    margin: 0;
+    padding: 0;
+    list-style: none;
     display: grid;
-    grid-template-columns: 280px 1fr;
-    gap: 32px;
-    padding: 44px 56px 56px;
+    gap: 6px;
+    font-size: 12px;
+    color: rgba(248, 250, 252, 0.75);
+    text-align: right;
 }
 
-.darkmode-sidebar {
+.darkmode-body {
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr);
+    gap: 40px;
+    padding: 48px 56px 56px;
+}
+
+.darkmode-aside {
     display: flex;
     flex-direction: column;
     gap: 24px;
 }
 
-.darkmode-card {
-    background: var(--darkmode-panel);
+.darkmode-aside section {
     border: 1px solid var(--darkmode-border);
     border-radius: 24px;
-    padding: 24px;
-    color: var(--darkmode-muted);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
-}
-
-.darkmode-card h2,
-.darkmode-section h2 {
-    margin: 0 0 12px;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.3em;
-    color: rgba(226, 232, 240, 0.7);
-}
-
-.darkmode-card p {
-    margin: 0;
-    color: var(--darkmode-muted);
-}
-
-.darkmode-card ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 8px;
-    font-size: 12px;
-    color: var(--darkmode-muted);
-}
-
-.darkmode-tag-list {
+    padding: 22px;
+    background: rgba(15, 23, 42, 0.75);
     display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
+    flex-direction: column;
+    gap: 12px;
 }
 
-.darkmode-tag-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(56, 189, 248, 0.18);
-    color: var(--darkmode-text);
-}
-
-.darkmode-language {
-    list-style: none;
+.darkmode-aside h2 {
     margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 6px;
     font-size: 12px;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--darkmode-muted);
 }
 
-.darkmode-language li {
+.darkmode-aside p {
+    margin: 0;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.darkmode-aside ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+    font-size: 13px;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.darkmode-aside li {
     display: flex;
     justify-content: space-between;
-    color: var(--darkmode-muted);
-}
-
-.darkmode-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 6px;
-    color: var(--darkmode-muted);
+    gap: 10px;
 }
 
 .darkmode-main {
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: 36px;
 }
 
 .darkmode-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 24px;
+}
+
+.darkmode-section h2 {
+    margin: 0;
+    font-size: 24px;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.85);
 }
 
 .darkmode-timeline {
     display: grid;
-    gap: 18px;
+    gap: 24px;
+    position: relative;
+    padding-left: 28px;
 }
 
-.darkmode-timeline__item {
-    display: grid;
-    grid-template-columns: 12px 1fr;
-    gap: 18px;
+.darkmode-timeline::before {
+    content: "";
+    position: absolute;
+    left: 12px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, rgba(34, 211, 238, 0.3), rgba(168, 85, 247, 0.3));
+}
+
+.darkmode-timeline article {
+    position: relative;
+    display: flex;
 }
 
 .darkmode-timeline__line {
-    width: 12px;
-    border-radius: 12px;
-    background: linear-gradient(180deg, rgba(56, 189, 248, 0.4), rgba(14, 165, 233, 0.2));
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 3px solid rgba(34, 211, 238, 0.9);
+    background: var(--darkmode-bg);
+    position: absolute;
+    left: -28px;
+    top: 6px;
 }
 
 .darkmode-timeline__content {
-    background: rgba(11, 17, 32, 0.8);
-    border: 1px solid rgba(56, 189, 248, 0.25);
-    border-radius: 22px;
-    padding: 18px 22px;
-    display: grid;
-    gap: 8px;
+    border-radius: 24px;
+    border: 1px solid var(--darkmode-border);
+    background: rgba(15, 23, 42, 0.78);
+    padding: 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 20px 30px rgba(15, 23, 42, 0.4);
 }
 
 .darkmode-timeline__content header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
     gap: 16px;
+    align-items: flex-start;
 }
 
 .darkmode-timeline__content h3 {
     margin: 0;
     font-size: 18px;
-    color: var(--darkmode-text);
+    color: #f8fafc;
 }
 
-.darkmode-timeline__content span {
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: rgba(148, 163, 184, 0.7);
-}
-
-.darkmode-meta {
-    margin: 0;
-    font-size: 12px;
+.darkmode-timeline__content p {
+    margin: 8px 0 0;
     color: var(--darkmode-muted);
 }
 
-.darkmode-summary {
+.darkmode-timeline__content span {
+    font-size: 12px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(248, 250, 252, 0.6);
+}
+
+.darkmode-timeline__content > p {
     margin: 0;
-    font-size: 13px;
-    color: var(--darkmode-text);
+    color: rgba(226, 232, 240, 0.85);
 }
 
 .darkmode-education {
     display: grid;
-    gap: 16px;
+    gap: 20px;
 }
 
 .darkmode-education article {
-    background: rgba(11, 17, 32, 0.7);
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    border-radius: 20px;
-    padding: 18px 22px;
-    display: grid;
-    gap: 8px;
+    border-radius: 24px;
+    border: 1px solid var(--darkmode-border);
+    background: rgba(15, 23, 42, 0.78);
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .darkmode-education header {
     display: flex;
     justify-content: space-between;
+    gap: 12px;
     align-items: baseline;
-    gap: 16px;
 }
 
 .darkmode-education h3 {
     margin: 0;
-    font-size: 17px;
-    color: var(--darkmode-text);
+    font-size: 18px;
 }
 
 .darkmode-education span {
-    font-size: 11px;
+    font-size: 12px;
+    letter-spacing: 0.2em;
     text-transform: uppercase;
-    letter-spacing: 0.18em;
-    color: rgba(148, 163, 184, 0.7);
+    color: rgba(248, 250, 252, 0.6);
+}
+
+.darkmode-education p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.darkmode-meta {
+    color: var(--darkmode-muted);
+}
+
+@media (max-width: 860px) {
+    body.darkmode-template {
+        padding: 32px;
+    }
+
+    .darkmode-body {
+        grid-template-columns: 1fr;
+    }
+
+    .darkmode-contact {
+        text-align: left;
+    }
 }

--- a/public/templates/css/futuristic.css
+++ b/public/templates/css/futuristic.css
@@ -1,11 +1,10 @@
 :root {
     --futuristic-bg: #020617;
-    --futuristic-panel: rgba(15, 23, 42, 0.92);
-    --futuristic-border: rgba(129, 140, 248, 0.3);
-    --futuristic-text: #e0e7ff;
-    --futuristic-muted: #a5b4fc;
-    --futuristic-accent: #818cf8;
-    --futuristic-secondary: #38bdf8;
+    --futuristic-surface: rgba(2, 6, 23, 0.92);
+    --futuristic-border: rgba(94, 234, 212, 0.4);
+    --futuristic-accent: #38bdf8;
+    --futuristic-accent-2: #a855f7;
+    --futuristic-muted: rgba(148, 163, 184, 0.78);
 }
 
 * {
@@ -14,33 +13,33 @@
 
 body.futuristic-template {
     margin: 0;
-    font-family: 'Inter', 'Space Grotesk', sans-serif;
-    background: linear-gradient(160deg, rgba(129, 140, 248, 0.25), rgba(56, 189, 248, 0.25));
-    color: var(--futuristic-text);
-    font-size: 14px;
+    font-family: "Sora", "Inter", sans-serif;
+    background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.25), transparent 55%),
+        radial-gradient(circle at bottom left, rgba(168, 85, 247, 0.25), transparent 50%),
+        var(--futuristic-bg);
+    color: #ecfeff;
+    font-size: 13px;
     line-height: 1.7;
     padding: 60px;
 }
 
-.futuristic-shell {
+.futuristic-frame {
     max-width: 980px;
     margin: 0 auto;
-    background: rgba(15, 23, 42, 0.95);
-    border-radius: 32px;
-    border: 1px solid var(--futuristic-border);
-    box-shadow: 0 40px 90px rgba(2, 6, 23, 0.65);
+    background: var(--futuristic-surface);
+    border-radius: 36px;
     overflow: hidden;
+    border: 1px solid rgba(56, 189, 248, 0.35);
+    box-shadow: 0 60px 90px rgba(15, 23, 42, 0.45);
 }
 
 .futuristic-header {
     padding: 48px 56px;
+    background: linear-gradient(135deg, rgba(56, 189, 248, 0.35), rgba(168, 85, 247, 0.35));
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 24px;
-    background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.35), transparent 55%),
-        radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.25), transparent 55%),
-        rgba(15, 23, 42, 0.9);
+    gap: 36px;
 }
 
 .futuristic-identity {
@@ -50,17 +49,18 @@ body.futuristic-template {
 }
 
 .futuristic-avatar {
-    width: 92px;
-    height: 92px;
-    border-radius: 28px;
-    background: rgba(2, 6, 23, 0.6);
-    border: 1px solid var(--futuristic-border);
+    width: 96px;
+    height: 96px;
+    border-radius: 30px;
+    background: rgba(15, 23, 42, 0.4);
+    border: 3px solid rgba(236, 254, 255, 0.5);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 30px;
-    font-weight: 600;
-    color: var(--futuristic-accent);
+    font-size: 36px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #ecfeff;
     overflow: hidden;
 }
 
@@ -71,215 +71,233 @@ body.futuristic-template {
 }
 
 .futuristic-badge {
+    margin: 0;
     text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 10px;
-    color: rgba(165, 180, 252, 0.7);
+    letter-spacing: 0.4em;
+    font-size: 11px;
+    color: rgba(236, 254, 255, 0.7);
 }
 
 .futuristic-header h1 {
-    margin: 6px 0 0;
-    font-size: 32px;
-    letter-spacing: 0.04em;
+    margin: 8px 0 0;
+    font-size: 36px;
 }
 
-.futuristic-headline {
+.futuristic-header p {
     margin: 6px 0 0;
-    color: rgba(165, 180, 252, 0.75);
-    font-size: 14px;
+    font-size: 15px;
+    color: rgba(236, 254, 255, 0.75);
 }
 
 .futuristic-location {
+    color: rgba(148, 163, 184, 0.75);
+}
+
+.futuristic-contact {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 6px;
     font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.28em;
-    color: rgba(129, 140, 248, 0.8);
+    color: rgba(236, 254, 255, 0.78);
+    text-align: right;
+}
+
+.futuristic-body {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+    padding: 48px 56px 60px;
 }
 
 .futuristic-grid {
     display: grid;
-    grid-template-columns: 300px 1fr;
-    gap: 36px;
-    padding: 44px 56px 56px;
-}
-
-.futuristic-sidebar {
-    display: flex;
-    flex-direction: column;
     gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .futuristic-panel {
-    background: var(--futuristic-panel);
-    border: 1px solid var(--futuristic-border);
-    border-radius: 24px;
+    border-radius: 26px;
     padding: 24px;
-    color: var(--futuristic-muted);
-    box-shadow: inset 0 0 0 1px rgba(129, 140, 248, 0.08);
+    background: linear-gradient(150deg, rgba(56, 189, 248, 0.22), rgba(2, 6, 23, 0.65));
+    border: 1px solid rgba(56, 189, 248, 0.32);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
-.futuristic-panel h2,
-.futuristic-section h2 {
-    margin: 0 0 12px;
-    font-size: 13px;
+.futuristic-panel h2 {
+    margin: 0;
+    font-size: 12px;
+    letter-spacing: 0.36em;
     text-transform: uppercase;
-    letter-spacing: 0.3em;
-    color: rgba(224, 231, 255, 0.7);
+    color: rgba(236, 254, 255, 0.78);
 }
 
 .futuristic-panel p {
     margin: 0;
-    color: var(--futuristic-muted);
+    color: rgba(236, 254, 255, 0.88);
 }
 
 .futuristic-panel ul {
-    list-style: none;
     margin: 0;
     padding: 0;
+    list-style: none;
     display: grid;
     gap: 8px;
-    font-size: 12px;
-    color: var(--futuristic-muted);
+    font-size: 13px;
+    color: rgba(236, 254, 255, 0.85);
 }
 
-.futuristic-tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.futuristic-tag-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(129, 140, 248, 0.2);
-    color: var(--futuristic-text);
-}
-
-.futuristic-language {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 6px;
-    font-size: 12px;
-}
-
-.futuristic-language li {
+.futuristic-panel li {
     display: flex;
     justify-content: space-between;
-}
-
-.futuristic-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 6px;
-    color: var(--futuristic-muted);
-}
-
-.futuristic-main {
-    display: flex;
-    flex-direction: column;
-    gap: 32px;
+    gap: 10px;
 }
 
 .futuristic-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 24px;
 }
 
-.futuristic-cards {
-    display: grid;
-    gap: 18px;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+.futuristic-section h2 {
+    margin: 0;
+    font-size: 24px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(236, 254, 255, 0.85);
 }
 
-.futuristic-card {
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(37, 99, 235, 0.12));
-    border: 1px solid rgba(129, 140, 248, 0.25);
-    border-radius: 20px;
-    padding: 20px;
+.futuristic-timeline {
     display: grid;
+    gap: 26px;
+    position: relative;
+    padding-left: 36px;
+}
+
+.futuristic-timeline::before {
+    content: "";
+    position: absolute;
+    left: 14px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(to bottom, rgba(56, 189, 248, 0.4), rgba(168, 85, 247, 0.4));
+}
+
+.futuristic-timeline article {
+    position: relative;
+}
+
+.futuristic-timeline__marker {
+    position: absolute;
+    left: -32px;
+    top: 6px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 4px solid rgba(56, 189, 248, 0.9);
+    background: var(--futuristic-bg);
+}
+
+.futuristic-timeline__card {
+    border-radius: 26px;
+    border: 1px solid rgba(56, 189, 248, 0.32);
+    background: rgba(2, 6, 23, 0.85);
+    padding: 24px 26px;
+    display: flex;
+    flex-direction: column;
     gap: 12px;
-    color: var(--futuristic-muted);
-    box-shadow: 0 20px 40px rgba(2, 6, 23, 0.45);
+    box-shadow: 0 25px 40px rgba(15, 23, 42, 0.45);
 }
 
-.futuristic-card header {
+.futuristic-timeline__card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.futuristic-timeline__card h3 {
+    margin: 0;
+    font-size: 20px;
+    color: #ecfeff;
+}
+
+.futuristic-timeline__card p {
+    margin: 8px 0 0;
+    color: var(--futuristic-muted);
+}
+
+.futuristic-timeline__card span {
+    font-size: 12px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(236, 254, 255, 0.65);
+}
+
+.futuristic-timeline__card > p {
+    margin: 0;
+    color: rgba(236, 254, 255, 0.9);
+}
+
+.futuristic-education {
+    display: grid;
+    gap: 22px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.futuristic-education article {
+    border-radius: 24px;
+    border: 1px solid rgba(168, 85, 247, 0.32);
+    background: rgba(2, 6, 23, 0.8);
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.futuristic-education__head {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    gap: 16px;
+    gap: 12px;
 }
 
-.futuristic-card h3 {
+.futuristic-education__head h3 {
     margin: 0;
     font-size: 18px;
-    color: var(--futuristic-text);
 }
 
-.futuristic-card p {
-    margin: 4px 0 0;
+.futuristic-education__head span {
     font-size: 12px;
-}
-
-.futuristic-card span {
-    font-size: 11px;
-    text-transform: uppercase;
     letter-spacing: 0.2em;
-    color: rgba(129, 140, 248, 0.8);
+    text-transform: uppercase;
+    color: rgba(236, 254, 255, 0.6);
 }
 
-.futuristic-meta {
+.futuristic-education p {
     margin: 0;
-    font-size: 12px;
+    color: rgba(236, 254, 255, 0.85);
+}
+
+.futuristic-education__meta {
     color: var(--futuristic-muted);
 }
 
-.futuristic-summary {
-    margin: 0;
-    font-size: 13px;
-    color: var(--futuristic-text);
-}
+@media (max-width: 860px) {
+    body.futuristic-template {
+        padding: 32px;
+    }
 
-.futuristic-table {
-    display: grid;
-    gap: 16px;
-}
+    .futuristic-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 
-.futuristic-row {
-    display: flex;
-    justify-content: space-between;
-    gap: 18px;
-    background: rgba(15, 23, 42, 0.85);
-    border: 1px solid rgba(56, 189, 248, 0.25);
-    border-radius: 18px;
-    padding: 18px;
-}
-
-.futuristic-row h3 {
-    margin: 0;
-    font-size: 16px;
-    color: var(--futuristic-text);
-}
-
-.futuristic-row p {
-    margin: 4px 0 0;
-    font-size: 12px;
-    color: var(--futuristic-muted);
-}
-
-.futuristic-row__meta {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: rgba(129, 140, 248, 0.75);
+    .futuristic-contact {
+        text-align: left;
+    }
 }

--- a/public/templates/css/gradient.css
+++ b/public/templates/css/gradient.css
@@ -1,9 +1,10 @@
 :root {
-    --gradient-primary: #14b8a6;
-    --gradient-secondary: #6366f1;
-    --gradient-dark: #0f172a;
-    --gradient-muted: #475569;
-    --gradient-light: #f8fafc;
+    --gradient-deep: #111827;
+    --gradient-purple: #6d28d9;
+    --gradient-blue: #2563eb;
+    --gradient-pink: #db2777;
+    --gradient-soft: #f5f3ff;
+    --gradient-muted: #e2e8f0;
 }
 
 * {
@@ -12,171 +13,102 @@
 
 body.gradient-template {
     margin: 0;
-    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: linear-gradient(135deg, rgba(20, 184, 166, 0.16), rgba(99, 102, 241, 0.16));
-    color: var(--gradient-dark);
-    font-size: 14px;
-    line-height: 1.6;
-    padding: 52px;
-}
-
-.gradient-page {
-    max-width: 960px;
-    margin: 0 auto;
-    background: rgba(255, 255, 255, 0.95);
-    border-radius: 34px;
-    border: 1px solid rgba(99, 102, 241, 0.15);
-    box-shadow: 0 40px 80px rgba(15, 23, 42, 0.15);
-    overflow: hidden;
-}
-
-.gradient-header {
-    padding: 48px;
-    background: radial-gradient(circle at top left, rgba(20, 184, 166, 0.3), transparent 60%),
-        radial-gradient(circle at top right, rgba(99, 102, 241, 0.3), transparent 60%),
+    font-family: "Poppins", "Inter", sans-serif;
+    background: radial-gradient(circle at top right, rgba(37, 99, 235, 0.3), transparent 55%),
+        radial-gradient(circle at bottom left, rgba(219, 39, 119, 0.25), transparent 50%),
         #0f172a;
-    color: #fff;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+    color: #f8fafc;
+    font-size: 13px;
+    line-height: 1.7;
+    padding: 56px;
+}
+
+.gradient-wrapper {
+    max-width: 980px;
+    margin: 0 auto;
+    border-radius: 36px;
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.92);
+    border: 1px solid rgba(99, 102, 241, 0.35);
+    box-shadow: 0 60px 90px rgba(15, 23, 42, 0.45);
 }
 
 .gradient-hero {
+    padding: 48px 56px;
+    display: flex;
+    justify-content: space-between;
+    gap: 36px;
+    align-items: center;
+    background: linear-gradient(135deg, rgba(109, 40, 217, 0.75), rgba(37, 99, 235, 0.55));
+}
+
+.gradient-profile {
     display: flex;
     align-items: center;
     gap: 24px;
 }
 
 .gradient-avatar {
-    width: 90px;
-    height: 90px;
+    width: 96px;
+    height: 96px;
     border-radius: 28px;
-    background: rgba(15, 23, 42, 0.25);
-    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.35);
+    border: 3px solid rgba(248, 250, 252, 0.45);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 30px;
-    font-weight: 600;
+    font-size: 36px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: #f8fafc;
+    overflow: hidden;
 }
 
 .gradient-avatar img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    border-radius: 28px;
 }
 
 .gradient-badge {
+    display: inline-block;
     text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 10px;
-    color: rgba(255, 255, 255, 0.65);
-    margin: 0 0 8px;
+    letter-spacing: 0.4em;
+    font-size: 11px;
+    color: rgba(248, 250, 252, 0.75);
 }
 
-.gradient-header h1 {
-    margin: 0;
-    font-size: 32px;
-    letter-spacing: 0.02em;
+.gradient-hero h1 {
+    margin: 8px 0 0;
+    font-size: 36px;
 }
 
-.gradient-headline {
+.gradient-hero p {
     margin: 6px 0 0;
-    color: rgba(255, 255, 255, 0.7);
     font-size: 15px;
+    color: rgba(248, 250, 252, 0.78);
 }
 
 .gradient-location {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.28em;
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(248, 250, 252, 0.65);
 }
 
-.gradient-content {
-    display: grid;
-    grid-template-columns: 300px 1fr;
-    gap: 32px;
-    padding: 44px 52px 52px;
-}
-
-.gradient-sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.gradient-card {
-    border-radius: 26px;
-    padding: 24px;
-    border: 1px solid rgba(20, 184, 166, 0.2);
-    background: rgba(248, 250, 252, 0.95);
-    color: var(--gradient-muted);
-}
-
-.gradient-card--highlight {
-    background: linear-gradient(140deg, rgba(20, 184, 166, 0.15), rgba(99, 102, 241, 0.15));
-    color: var(--gradient-dark);
-}
-
-.gradient-card h2,
-.gradient-section h2 {
-    margin: 0 0 12px;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.32em;
-}
-
-.gradient-card ul {
+.gradient-contact {
     margin: 0;
     padding: 0;
     list-style: none;
-    display: grid;
-    gap: 8px;
-    font-size: 12px;
-}
-
-.gradient-tag-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.gradient-tag-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(20, 184, 166, 0.15);
-    color: var(--gradient-dark);
-    font-size: 12px;
-}
-
-.gradient-language {
-    list-style: none;
-    margin: 0;
-    padding: 0;
     display: grid;
     gap: 6px;
     font-size: 12px;
-    color: var(--gradient-muted);
+    color: rgba(248, 250, 252, 0.78);
+    text-align: right;
 }
 
-.gradient-language li {
-    display: flex;
-    justify-content: space-between;
-}
-
-.gradient-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
+.gradient-columns {
     display: grid;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--gradient-muted);
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: 40px;
+    padding: 48px 56px 56px;
 }
 
 .gradient-main {
@@ -188,96 +120,154 @@ body.gradient-template {
 .gradient-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 24px;
 }
 
-.gradient-experience {
+.gradient-section h2 {
+    margin: 0;
+    font-size: 24px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.gradient-grid {
     display: grid;
-    gap: 18px;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.gradient-experience__item {
-    border-radius: 24px;
-    border: 1px solid rgba(99, 102, 241, 0.18);
-    padding: 22px;
-    background: rgba(255, 255, 255, 0.9);
-    box-shadow: 0 20px 40px rgba(99, 102, 241, 0.15);
+.gradient-grid article {
+    border-radius: 28px;
+    padding: 28px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.18), rgba(219, 39, 119, 0.28));
+    border: 1px solid rgba(99, 102, 241, 0.4);
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
 }
 
-.gradient-experience__header {
+.gradient-grid header {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 16px;
+    gap: 14px;
+    align-items: flex-start;
 }
 
-.gradient-experience__header h3 {
+.gradient-grid h3 {
     margin: 0;
-    font-size: 18px;
-    color: var(--gradient-dark);
+    font-size: 20px;
 }
 
-.gradient-experience__header p {
-    margin: 6px 0 0;
-    font-size: 13px;
-    color: var(--gradient-muted);
-}
-
-.gradient-chip {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: rgba(99, 102, 241, 0.12);
-    color: var(--gradient-secondary);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-}
-
-.gradient-meta {
+.gradient-grid p {
     margin: 8px 0 0;
-    font-size: 12px;
-    color: var(--gradient-muted);
+    color: rgba(226, 232, 240, 0.78);
 }
 
-.gradient-summary {
-    margin: 10px 0 0;
-    font-size: 13px;
-    color: var(--gradient-dark);
+.gradient-grid span {
+    font-size: 12px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.72);
 }
 
 .gradient-education {
     display: grid;
-    gap: 18px;
+    gap: 20px;
 }
 
-.gradient-education__item {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 18px;
-    padding: 18px;
-    border-radius: 22px;
-    border: 1px solid rgba(20, 184, 166, 0.18);
-    background: rgba(248, 250, 252, 0.95);
-}
-
-.gradient-education__item h3 {
-    margin: 0;
-    font-size: 17px;
-}
-
-.gradient-education__item p {
-    margin: 4px 0 0;
-    font-size: 12px;
-    color: var(--gradient-muted);
-}
-
-.gradient-education__meta {
+.gradient-education article {
+    border-radius: 24px;
+    padding: 24px;
+    background: rgba(15, 23, 42, 0.65);
+    border: 1px solid rgba(148, 163, 184, 0.25);
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    font-size: 11px;
-    text-transform: uppercase;
+    gap: 10px;
+}
+
+.gradient-education header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: baseline;
+}
+
+.gradient-education h3 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.gradient-education span {
+    font-size: 12px;
     letter-spacing: 0.2em;
-    color: var(--gradient-muted);
+    text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.65);
+}
+
+.gradient-education p {
+    margin: 0;
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.gradient-meta {
+    color: rgba(148, 163, 184, 0.78);
+}
+
+.gradient-aside {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+.gradient-card {
+    border-radius: 24px;
+    padding: 24px;
+    background: linear-gradient(160deg, rgba(109, 40, 217, 0.24), rgba(37, 99, 235, 0.18));
+    border: 1px solid rgba(99, 102, 241, 0.28);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.gradient-card h2 {
+    margin: 0;
+    font-size: 12px;
+    letter-spacing: 0.4em;
+    text-transform: uppercase;
+    color: rgba(248, 250, 252, 0.75);
+}
+
+.gradient-card p {
+    margin: 0;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.gradient-card ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+    font-size: 13px;
+    color: rgba(248, 250, 252, 0.85);
+}
+
+.gradient-card li {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+@media (max-width: 860px) {
+    body.gradient-template {
+        padding: 28px;
+    }
+
+    .gradient-columns {
+        grid-template-columns: 1fr;
+    }
+
+    .gradient-contact {
+        text-align: left;
+    }
 }

--- a/public/templates/css/minimal.css
+++ b/public/templates/css/minimal.css
@@ -1,11 +1,9 @@
 :root {
-    --minimal-slate-900: #0f172a;
-    --minimal-slate-700: #334155;
-    --minimal-slate-500: #64748b;
-    --minimal-slate-300: #cbd5f5;
-    --minimal-slate-200: #e2e8f0;
-    --minimal-slate-100: #f8fafc;
-    --minimal-accent: #0f172a;
+    --minimal-ink: #0f172a;
+    --minimal-muted: #475569;
+    --minimal-soft: #f1f5f9;
+    --minimal-border: #e2e8f0;
+    --minimal-accent: #111827;
 }
 
 * {
@@ -14,53 +12,50 @@
 
 body.minimal-template {
     margin: 0;
-    font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
-    background: var(--minimal-slate-100);
-    color: var(--minimal-slate-900);
+    font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
+    background: #ffffff;
+    color: var(--minimal-ink);
     font-size: 13px;
     line-height: 1.6;
     padding: 48px;
 }
 
 .minimal-page {
-    max-width: 980px;
+    max-width: 860px;
     margin: 0 auto;
-    background: #fff;
-    border-radius: 32px;
-    border: 1px solid var(--minimal-slate-200);
-    box-shadow: 0 30px 60px rgba(15, 23, 42, 0.08);
+    border: 1px solid var(--minimal-border);
+    border-radius: 28px;
     overflow: hidden;
-    display: flex;
-    flex-direction: column;
+    box-shadow: 0 40px 70px rgba(15, 23, 42, 0.08);
 }
 
 .minimal-header {
-    padding: 40px 48px;
-    border-bottom: 1px solid var(--minimal-slate-200);
+    padding: 40px;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.05), rgba(15, 23, 42, 0.02));
     display: flex;
-    align-items: center;
     justify-content: space-between;
-    gap: 24px;
+    gap: 32px;
+    align-items: center;
 }
 
-.minimal-header__identity {
+.minimal-identity {
     display: flex;
-    align-items: center;
     gap: 20px;
+    align-items: center;
 }
 
 .minimal-avatar {
-    width: 88px;
-    height: 88px;
-    border-radius: 24px;
-    background: var(--minimal-slate-100);
-    border: 1px solid var(--minimal-slate-200);
+    width: 80px;
+    height: 80px;
+    border-radius: 22px;
+    border: 1px solid var(--minimal-border);
+    background: var(--minimal-soft);
     display: flex;
     align-items: center;
     justify-content: center;
     font-size: 28px;
     font-weight: 600;
-    color: var(--minimal-slate-500);
+    color: var(--minimal-muted);
     overflow: hidden;
 }
 
@@ -70,150 +65,43 @@ body.minimal-template {
     object-fit: cover;
 }
 
-.minimal-header__identity h1 {
+.minimal-identity h1 {
     margin: 0;
-    font-size: 28px;
-    letter-spacing: 0.02em;
+    font-size: 30px;
+    letter-spacing: 0.01em;
 }
 
-.minimal-header__identity p {
+.minimal-identity p {
     margin: 6px 0 0;
-    color: var(--minimal-slate-500);
+    color: var(--minimal-muted);
     font-size: 14px;
 }
 
-.minimal-header__meta {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 10px;
-    font-size: 12px;
-    color: var(--minimal-slate-500);
+.minimal-contact {
+    margin-left: auto;
 }
 
-.minimal-badge {
-    text-transform: uppercase;
-    letter-spacing: 0.32em;
-    font-size: 10px;
-    color: var(--minimal-slate-500);
-}
-
-.minimal-columns {
-    display: grid;
-    grid-template-columns: 280px 1fr;
-    gap: 36px;
-    padding: 40px 48px;
-}
-
-.minimal-sidebar {
-    display: flex;
-    flex-direction: column;
-    gap: 28px;
-}
-
-.minimal-sidebar section h2,
-.minimal-section h2 {
-    margin: 0 0 12px;
+.minimal-contact h2 {
+    margin: 0 0 8px;
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.32em;
-    color: var(--minimal-slate-500);
+    color: var(--minimal-muted);
 }
 
-.minimal-sidebar section ul,
-.minimal-sidebar section p {
+.minimal-contact ul {
     margin: 0;
     padding: 0;
     list-style: none;
-    font-size: 12px;
-    color: var(--minimal-slate-700);
-}
-
-.minimal-sidebar section ul li + li {
-    margin-top: 6px;
-}
-
-.minimal-pill-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.minimal-pill-list li {
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: var(--minimal-slate-100);
-    border: 1px solid var(--minimal-slate-200);
-    font-size: 12px;
-}
-
-.minimal-language-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
     display: grid;
     gap: 6px;
     font-size: 12px;
-}
-
-.minimal-language-list li {
-    display: flex;
-    justify-content: space-between;
-    gap: 12px;
-}
-
-.minimal-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--minimal-slate-700);
-}
-
-.minimal-list--spaced {
-    gap: 14px;
-}
-
-.minimal-list--spaced li {
-    display: flex;
-    justify-content: space-between;
-    gap: 18px;
-    align-items: baseline;
-    border-bottom: 1px solid var(--minimal-slate-200);
-    padding-bottom: 12px;
-}
-
-.minimal-list--spaced li:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
-.minimal-list--spaced h3 {
-    margin: 0;
-    font-size: 15px;
-}
-
-.minimal-list--spaced span {
-    display: block;
-    margin-top: 4px;
-    font-size: 12px;
-    color: var(--minimal-slate-500);
-}
-
-.minimal-list__meta {
+    color: var(--minimal-muted);
     text-align: right;
-    font-size: 11px;
-    color: var(--minimal-slate-500);
-    text-transform: uppercase;
-    letter-spacing: 0.18em;
 }
 
-.minimal-main {
+.minimal-body {
+    padding: 40px;
     display: flex;
     flex-direction: column;
     gap: 32px;
@@ -222,49 +110,160 @@ body.minimal-template {
 .minimal-section {
     display: flex;
     flex-direction: column;
-    gap: 18px;
+    gap: 20px;
+}
+
+.minimal-section h2 {
+    margin: 0;
+    font-size: 12px;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--minimal-muted);
+}
+
+.minimal-section--summary p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--minimal-ink);
 }
 
 .minimal-timeline {
     display: grid;
-    gap: 16px;
+    gap: 24px;
+    border-left: 1px solid var(--minimal-border);
+    padding-left: 24px;
 }
 
-.minimal-timeline__item {
-    display: grid;
-    grid-template-columns: 12px 1fr;
-    gap: 18px;
+.minimal-timeline article {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
-.minimal-timeline__bar {
-    width: 12px;
-    border-radius: 12px;
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.15), rgba(15, 23, 42, 0.05));
+.minimal-timeline header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
 }
 
-.minimal-timeline__content h3 {
+.minimal-timeline h3 {
     margin: 0;
     font-size: 16px;
     color: var(--minimal-accent);
 }
 
-.minimal-timeline__content p {
-    margin: 6px 0 0;
-    font-size: 12px;
-    color: var(--minimal-slate-500);
+.minimal-timeline p {
+    margin: 0;
+    font-size: 13px;
+    color: var(--minimal-muted);
 }
 
-.minimal-timeline__content span {
-    display: inline-block;
-    margin-top: 6px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.2em;
-    color: var(--minimal-slate-500);
+.minimal-timeline span {
+    font-size: 12px;
+    color: var(--minimal-muted);
 }
 
 .minimal-note {
-    margin-top: 10px;
+    margin: 0;
+    font-size: 13px;
+    color: var(--minimal-ink);
+}
+
+.minimal-education {
+    display: grid;
+    gap: 18px;
+}
+
+.minimal-education article {
+    padding: 16px;
+    border: 1px solid var(--minimal-border);
+    border-radius: 16px;
+    background: #fff;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.minimal-education header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+.minimal-education h3 {
+    margin: 0;
+    font-size: 15px;
+    color: var(--minimal-accent);
+}
+
+.minimal-education span {
     font-size: 12px;
-    color: var(--minimal-slate-700);
+    color: var(--minimal-muted);
+}
+
+.minimal-education p {
+    margin: 0;
+    font-size: 13px;
+    color: var(--minimal-ink);
+}
+
+.minimal-muted {
+    color: var(--minimal-muted);
+}
+
+.minimal-section--grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.minimal-card {
+    border: 1px solid var(--minimal-border);
+    border-radius: 18px;
+    padding: 20px;
+    background: var(--minimal-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.minimal-card h2 {
+    font-size: 12px;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--minimal-muted);
+    margin: 0;
+}
+
+.minimal-card ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--minimal-ink);
+}
+
+.minimal-card li {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+@media (max-width: 720px) {
+    body.minimal-template {
+        padding: 24px;
+    }
+
+    .minimal-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .minimal-contact ul {
+        text-align: left;
+    }
 }

--- a/resources/views/templates/classic.blade.php
+++ b/resources/views/templates/classic.blade.php
@@ -9,16 +9,32 @@
     @php
         $templateData = \App\View\TemplateDataBuilder::fromCv($cv ?? null);
         $data = $templateData;
+        $initials = collect([$data['first_name'] ?? null, $data['last_name'] ?? null])
+            ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+            ->map(fn ($item) => mb_strtoupper(mb_substr(trim($item), 0, 1)))
+            ->implode('');
+        $profileImage = $data['profile_image'] ?? null;
     @endphp
 
     <div class="page">
         <header>
-            <div>
-                <span class="badge">{{ __('Classic Resume') }}</span>
-                <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
-                @if ($data['headline'])
-                    <p>{{ $data['headline'] }}</p>
-                @endif
+            <div class="identity">
+                <div class="portrait">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
+                    @elseif ($initials !== '')
+                        <span>{{ $initials }}</span>
+                    @else
+                        <span>{{ __('CV') }}</span>
+                    @endif
+                </div>
+                <div>
+                    <span class="badge">{{ __('Classic Resume') }}</span>
+                    <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
+                    @if ($data['headline'])
+                        <p>{{ $data['headline'] }}</p>
+                    @endif
+                </div>
             </div>
             <div class="contact">
                 @foreach ($data['contacts'] as $contact)

--- a/resources/views/templates/corporate.blade.php
+++ b/resources/views/templates/corporate.blade.php
@@ -16,9 +16,9 @@
         $profileImage = $data['profile_image'] ?? null;
     @endphp
 
-    <div class="corporate-page">
-        <header class="corporate-header">
-            <div class="corporate-header__identity">
+    <div class="corporate-wrapper">
+        <header class="corporate-topbar">
+            <div class="corporate-brand">
                 <div class="corporate-avatar">
                     @if ($profileImage)
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
@@ -29,44 +29,105 @@
                     @endif
                 </div>
                 <div>
+                    <p class="corporate-badge">{{ __('Corporate Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
                         <p>{{ $data['headline'] }}</p>
                     @endif
                 </div>
             </div>
-            <div class="corporate-header__details">
-                <span class="corporate-badge">{{ __('Corporate Resume') }}</span>
-                @if ($data['location'])
-                    <span>{{ $data['location'] }}</span>
-                @endif
-            </div>
+            @if (!empty($data['contacts']))
+                <ul class="corporate-contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <li>{{ $contact }}</li>
+                    @endforeach
+                </ul>
+            @endif
         </header>
 
-        <div class="corporate-grid">
-            <aside class="corporate-sidebar">
+        <div class="corporate-body">
+            <main class="corporate-main">
                 @if ($data['summary'])
-                    <section class="corporate-card">
-                        <h2>{{ __('Summary') }}</h2>
+                    <section class="corporate-section corporate-section--summary">
+                        <h2>{{ __('Profile') }}</h2>
                         <p>{{ $data['summary'] }}</p>
                     </section>
                 @endif
 
-                @if (!empty($data['contacts']))
-                    <section class="corporate-card">
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul>
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
+                @if (!empty($data['experiences']))
+                    <section class="corporate-section">
+                        <header>
+                            <h2>{{ __('Experience') }}</h2>
+                            <p>{{ __('Leadership, strategy, and measurable outcomes.') }}</p>
+                        </header>
+                        <div class="corporate-timeline">
+                            @foreach ($data['experiences'] as $experience)
+                                <article>
+                                    <div class="corporate-timeline__marker"></div>
+                                    <div class="corporate-timeline__body">
+                                        <div class="corporate-timeline__head">
+                                            <div>
+                                                @if ($experience['role'])
+                                                    <h3>{{ $experience['role'] }}</h3>
+                                                @endif
+                                                <p>
+                                                    {{ $experience['company'] }}
+                                                    @if ($experience['company'] && $experience['location'])
+                                                        ·
+                                                    @endif
+                                                    {{ $experience['location'] }}
+                                                </p>
+                                            </div>
+                                            @if ($experience['period'])
+                                                <span>{{ $experience['period'] }}</span>
+                                            @endif
+                                        </div>
+                                        @if ($experience['summary'])
+                                            <p class="corporate-timeline__summary">{{ $experience['summary'] }}</p>
+                                        @endif
+                                    </div>
+                                </article>
                             @endforeach
-                        </ul>
+                        </div>
                     </section>
                 @endif
 
+                @if (!empty($data['education']))
+                    <section class="corporate-section">
+                        <header>
+                            <h2>{{ __('Education') }}</h2>
+                            <p>{{ __('Degrees, certifications, and executive programs.') }}</p>
+                        </header>
+                        <div class="corporate-education">
+                            @foreach ($data['education'] as $education)
+                                <article>
+                                    <div class="corporate-education__head">
+                                        <h3>{{ $education['institution'] }}</h3>
+                                        @if ($education['period'])
+                                            <span>{{ $education['period'] }}</span>
+                                        @endif
+                                    </div>
+                                    @if ($education['degree'])
+                                        <p>{{ $education['degree'] }}</p>
+                                    @endif
+                                    @if ($education['field'])
+                                        <p>{{ $education['field'] }}</p>
+                                    @endif
+                                    @if ($education['location'])
+                                        <p class="corporate-education__location">{{ $education['location'] }}</p>
+                                    @endif
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+            </main>
+
+            <aside class="corporate-aside">
                 @if (!empty($data['skills']))
-                    <section class="corporate-card">
-                        <h2>{{ __('Skills') }}</h2>
-                        <ul class="corporate-pill-list">
+                    <section>
+                        <h2>{{ __('Core Skills') }}</h2>
+                        <ul>
                             @foreach ($data['skills'] as $skill)
                                 <li>{{ $skill }}</li>
                             @endforeach
@@ -75,9 +136,9 @@
                 @endif
 
                 @if (!empty($data['languages']))
-                    <section class="corporate-card">
+                    <section>
                         <h2>{{ __('Languages') }}</h2>
-                        <ul class="corporate-language">
+                        <ul>
                             @foreach ($data['languages'] as $language)
                                 <li>
                                     <span>{{ $language['name'] }}</span>
@@ -91,9 +152,9 @@
                 @endif
 
                 @if (!empty($data['hobbies']))
-                    <section class="corporate-card">
+                    <section>
                         <h2>{{ __('Interests') }}</h2>
-                        <ul class="corporate-list">
+                        <ul>
                             @foreach ($data['hobbies'] as $hobby)
                                 <li>{{ $hobby }}</li>
                             @endforeach
@@ -101,69 +162,6 @@
                     </section>
                 @endif
             </aside>
-
-            <main class="corporate-main">
-                @if (!empty($data['experiences']))
-                    <section class="corporate-section">
-                        <div class="corporate-section__head">
-                            <h2>{{ __('Experience') }}</h2>
-                            <p>{{ __('Career progression and leadership roles.') }}</p>
-                        </div>
-                        <div class="corporate-experience">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="corporate-experience__item">
-                                    <div class="corporate-experience__meta">
-                                        <h3>{{ $experience['role'] }}</h3>
-                                        @if ($experience['period'])
-                                            <span>{{ $experience['period'] }}</span>
-                                        @endif
-                                    </div>
-                                    <p class="corporate-experience__company">
-                                        {{ $experience['company'] }}
-                                        @if ($experience['company'] && $experience['location'])
-                                            ·
-                                        @endif
-                                        {{ $experience['location'] }}
-                                    </p>
-                                    @if ($experience['summary'])
-                                        <p class="corporate-experience__summary">{{ $experience['summary'] }}</p>
-                                    @endif
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-
-                @if (!empty($data['education']))
-                    <section class="corporate-section">
-                        <div class="corporate-section__head">
-                            <h2>{{ __('Education') }}</h2>
-                            <p>{{ __('Degrees, certifications, and recognitions.') }}</p>
-                        </div>
-                        <div class="corporate-education">
-                            @foreach ($data['education'] as $education)
-                                <article>
-                                    <div class="corporate-education__title">
-                                        <h3>{{ $education['degree'] ?? $education['institution'] }}</h3>
-                                        @if ($education['period'])
-                                            <span>{{ $education['period'] }}</span>
-                                        @endif
-                                    </div>
-                                    <p class="corporate-education__institution">{{ $education['institution'] }}</p>
-                                    <div class="corporate-education__meta">
-                                        @if ($education['field'])
-                                            <span>{{ $education['field'] }}</span>
-                                        @endif
-                                        @if ($education['location'])
-                                            <span>{{ $education['location'] }}</span>
-                                        @endif
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-            </main>
         </div>
     </div>
 </body>

--- a/resources/views/templates/creative.blade.php
+++ b/resources/views/templates/creative.blade.php
@@ -16,11 +16,10 @@
         $profileImage = $data['profile_image'] ?? null;
     @endphp
 
-    <div class="creative-page">
-        <header class="creative-hero">
-            <div class="creative-hero__badge">{{ __('Creative Resume') }}</div>
-            <div class="creative-hero__profile">
-                <div class="creative-hero__avatar">
+    <div class="creative-canvas">
+        <header class="creative-banner">
+            <div class="creative-nameplate">
+                <div class="creative-avatar">
                     @if ($profileImage)
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
                     @elseif ($initials !== '')
@@ -30,147 +29,138 @@
                     @endif
                 </div>
                 <div>
+                    <p class="creative-badge">{{ __('Creative Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
-                        <p>{{ $data['headline'] }}</p>
+                        <p class="creative-headline">{{ $data['headline'] }}</p>
                     @endif
                 </div>
             </div>
-            @if ($data['location'])
-                <div class="creative-hero__location">{{ $data['location'] }}</div>
+            @if (!empty($data['contacts']))
+                <ul class="creative-contact-list">
+                    @foreach ($data['contacts'] as $contact)
+                        <li>{{ $contact }}</li>
+                    @endforeach
+                </ul>
             @endif
         </header>
 
-        <div class="creative-content">
-            <aside class="creative-aside">
+        <main class="creative-body">
+            <section class="creative-intro">
                 @if ($data['summary'])
-                    <section class="creative-card creative-card--accent">
+                    <article class="creative-panel creative-panel--summary">
                         <h2>{{ __('Profile') }}</h2>
                         <p>{{ $data['summary'] }}</p>
-                    </section>
-                @endif
-
-                @if (!empty($data['contacts']))
-                    <section class="creative-card">
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul class="creative-list">
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
+                    </article>
                 @endif
 
                 @if (!empty($data['skills']))
-                    <section class="creative-card">
+                    <article class="creative-panel creative-panel--skills">
                         <h2>{{ __('Skills') }}</h2>
-                        <ul class="creative-tag-list">
+                        <ul>
                             @foreach ($data['skills'] as $skill)
                                 <li>{{ $skill }}</li>
                             @endforeach
                         </ul>
-                    </section>
+                    </article>
                 @endif
 
-                @if (!empty($data['languages']))
-                    <section class="creative-card creative-card--split">
-                        <h2>{{ __('Languages') }}</h2>
-                        <ul class="creative-list creative-list--condensed">
-                            @foreach ($data['languages'] as $language)
-                                <li>
-                                    <span class="creative-list__primary">{{ $language['name'] }}</span>
-                                    @if (!empty($language['level']))
-                                        <span class="creative-list__secondary">{{ ucfirst($language['level']) }}</span>
-                                    @endif
-                                </li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
-                @if (!empty($data['hobbies']))
-                    <section class="creative-card">
-                        <h2>{{ __('Interests') }}</h2>
-                        <ul class="creative-tag-list creative-tag-list--soft">
-                            @foreach ($data['hobbies'] as $hobby)
-                                <li>{{ $hobby }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-            </aside>
-
-            <main class="creative-main">
-                @if (!empty($data['experiences']))
-                    <section>
-                        <div class="creative-section-head">
-                            <h2>{{ __('Experience highlights') }}</h2>
-                            <p>{{ __('Selected projects and accomplishments.') }}</p>
-                        </div>
-                        <div class="creative-experience-grid">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="creative-experience-card">
-                                    <div class="creative-experience-card__header">
-                                        <span class="creative-dot"></span>
-                                        <div>
-                                            @if ($experience['role'])
-                                                <h3>{{ $experience['role'] }}</h3>
+                @if (!empty($data['languages']) || !empty($data['hobbies']))
+                    <article class="creative-panel creative-panel--extra">
+                        @if (!empty($data['languages']))
+                            <div>
+                                <h2>{{ __('Languages') }}</h2>
+                                <ul>
+                                    @foreach ($data['languages'] as $language)
+                                        <li>
+                                            <span>{{ $language['name'] }}</span>
+                                            @if (!empty($language['level']))
+                                                <span>{{ ucfirst($language['level']) }}</span>
                                             @endif
-                                            <p>
-                                                {{ $experience['company'] }}
-                                                @if ($experience['company'] && $experience['location'])
-                                                    ·
-                                                @endif
-                                                {{ $experience['location'] }}
-                                            </p>
-                                        </div>
-                                        @if ($experience['period'])
-                                            <span class="creative-chip">{{ $experience['period'] }}</span>
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                        @if (!empty($data['hobbies']))
+                            <div>
+                                <h2>{{ __('Interests') }}</h2>
+                                <ul>
+                                    @foreach ($data['hobbies'] as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </article>
+                @endif
+            </section>
+
+            @if (!empty($data['experiences']))
+                <section class="creative-section creative-section--experience">
+                    <header>
+                        <h2>{{ __('Experience Highlights') }}</h2>
+                        <p>{{ __('Projects and achievements that define your craft.') }}</p>
+                    </header>
+                    <div class="creative-experience">
+                        @foreach ($data['experiences'] as $experience)
+                            <article>
+                                <div class="creative-experience__meta">
+                                    <div>
+                                        @if ($experience['role'])
+                                            <h3>{{ $experience['role'] }}</h3>
                                         @endif
+                                        <p>
+                                            {{ $experience['company'] }}
+                                            @if ($experience['company'] && $experience['location'])
+                                                ·
+                                            @endif
+                                            {{ $experience['location'] }}
+                                        </p>
                                     </div>
-                                    @if ($experience['summary'])
-                                        <p class="creative-experience-card__body">{{ $experience['summary'] }}</p>
+                                    @if ($experience['period'])
+                                        <span>{{ $experience['period'] }}</span>
                                     @endif
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
+                                </div>
+                                @if ($experience['summary'])
+                                    <p class="creative-experience__summary">{{ $experience['summary'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
 
-                @if (!empty($data['education']))
-                    <section>
-                        <div class="creative-section-head">
-                            <h2>{{ __('Education') }}</h2>
-                            <p>{{ __('Studies, certifications, and workshops.') }}</p>
-                        </div>
-                        <div class="creative-education">
-                            @foreach ($data['education'] as $education)
-                                <article class="creative-education__item">
-                                    <div class="creative-education__timeline"></div>
-                                    <div class="creative-education__content">
-                                        <h3>{{ $education['institution'] }}</h3>
-                                        @if ($education['degree'])
-                                            <p class="creative-education__meta">{{ $education['degree'] }}</p>
-                                        @endif
-                                        @if ($education['field'])
-                                            <p class="creative-education__meta">{{ $education['field'] }}</p>
-                                        @endif
-                                        <div class="creative-education__footer">
-                                            @if ($education['location'])
-                                                <span>{{ $education['location'] }}</span>
-                                            @endif
-                                            @if ($education['period'])
-                                                <span>{{ $education['period'] }}</span>
-                                            @endif
-                                        </div>
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-            </main>
-        </div>
+            @if (!empty($data['education']))
+                <section class="creative-section creative-section--education">
+                    <header>
+                        <h2>{{ __('Education') }}</h2>
+                        <p>{{ __('Courses, certifications, and workshops.') }}</p>
+                    </header>
+                    <div class="creative-education">
+                        @foreach ($data['education'] as $education)
+                            <article>
+                                <div class="creative-education__head">
+                                    <h3>{{ $education['institution'] }}</h3>
+                                    @if ($education['period'])
+                                        <span>{{ $education['period'] }}</span>
+                                    @endif
+                                </div>
+                                @if ($education['degree'])
+                                    <p>{{ $education['degree'] }}</p>
+                                @endif
+                                @if ($education['field'])
+                                    <p>{{ $education['field'] }}</p>
+                                @endif
+                                @if ($education['location'])
+                                    <p class="creative-education__location">{{ $education['location'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
+        </main>
     </div>
 </body>
 </html>

--- a/resources/views/templates/darkmode.blade.php
+++ b/resources/views/templates/darkmode.blade.php
@@ -16,8 +16,8 @@
         $profileImage = $data['profile_image'] ?? null;
     @endphp
 
-    <div class="darkmode-page">
-        <header class="darkmode-hero">
+    <div class="darkmode-shell">
+        <header class="darkmode-header">
             <div class="darkmode-identity">
                 <div class="darkmode-avatar">
                     @if ($profileImage)
@@ -36,35 +36,28 @@
                     @endif
                 </div>
             </div>
-            @if ($data['location'])
-                <div class="darkmode-location">{{ $data['location'] }}</div>
+            @if (!empty($data['contacts']))
+                <ul class="darkmode-contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <li>{{ $contact }}</li>
+                    @endforeach
+                </ul>
             @endif
         </header>
 
-        <div class="darkmode-layout">
-            <aside class="darkmode-sidebar">
+        <div class="darkmode-body">
+            <aside class="darkmode-aside">
                 @if ($data['summary'])
-                    <section class="darkmode-card">
+                    <section>
                         <h2>{{ __('Profile') }}</h2>
                         <p>{{ $data['summary'] }}</p>
                     </section>
                 @endif
 
-                @if (!empty($data['contacts']))
-                    <section class="darkmode-card">
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul>
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
                 @if (!empty($data['skills']))
-                    <section class="darkmode-card">
+                    <section>
                         <h2>{{ __('Skills') }}</h2>
-                        <ul class="darkmode-tag-list">
+                        <ul>
                             @foreach ($data['skills'] as $skill)
                                 <li>{{ $skill }}</li>
                             @endforeach
@@ -73,9 +66,9 @@
                 @endif
 
                 @if (!empty($data['languages']))
-                    <section class="darkmode-card">
+                    <section>
                         <h2>{{ __('Languages') }}</h2>
-                        <ul class="darkmode-language">
+                        <ul>
                             @foreach ($data['languages'] as $language)
                                 <li>
                                     <span>{{ $language['name'] }}</span>
@@ -89,9 +82,9 @@
                 @endif
 
                 @if (!empty($data['hobbies']))
-                    <section class="darkmode-card">
+                    <section>
                         <h2>{{ __('Interests') }}</h2>
-                        <ul class="darkmode-list">
+                        <ul>
                             @foreach ($data['hobbies'] as $hobby)
                                 <li>{{ $hobby }}</li>
                             @endforeach
@@ -106,24 +99,28 @@
                         <h2>{{ __('Experience') }}</h2>
                         <div class="darkmode-timeline">
                             @foreach ($data['experiences'] as $experience)
-                                <article class="darkmode-timeline__item">
+                                <article>
                                     <div class="darkmode-timeline__line"></div>
                                     <div class="darkmode-timeline__content">
                                         <header>
-                                            <h3>{{ $experience['role'] }}</h3>
+                                            <div>
+                                                @if ($experience['role'])
+                                                    <h3>{{ $experience['role'] }}</h3>
+                                                @endif
+                                                <p>
+                                                    {{ $experience['company'] }}
+                                                    @if ($experience['company'] && $experience['location'])
+                                                        ·
+                                                    @endif
+                                                    {{ $experience['location'] }}
+                                                </p>
+                                            </div>
                                             @if ($experience['period'])
                                                 <span>{{ $experience['period'] }}</span>
                                             @endif
                                         </header>
-                                        <p class="darkmode-meta">
-                                            {{ $experience['company'] }}
-                                            @if ($experience['company'] && $experience['location'])
-                                                ·
-                                            @endif
-                                            {{ $experience['location'] }}
-                                        </p>
                                         @if ($experience['summary'])
-                                            <p class="darkmode-summary">{{ $experience['summary'] }}</p>
+                                            <p>{{ $experience['summary'] }}</p>
                                         @endif
                                     </div>
                                 </article>
@@ -144,9 +141,11 @@
                                             <span>{{ $education['period'] }}</span>
                                         @endif
                                     </header>
-                                    <p class="darkmode-meta">{{ $education['degree'] ?? '' }}</p>
+                                    @if ($education['degree'])
+                                        <p>{{ $education['degree'] }}</p>
+                                    @endif
                                     @if ($education['field'])
-                                        <p class="darkmode-meta">{{ $education['field'] }}</p>
+                                        <p>{{ $education['field'] }}</p>
                                     @endif
                                     @if ($education['location'])
                                         <p class="darkmode-meta">{{ $education['location'] }}</p>

--- a/resources/views/templates/futuristic.blade.php
+++ b/resources/views/templates/futuristic.blade.php
@@ -16,7 +16,7 @@
         $profileImage = $data['profile_image'] ?? null;
     @endphp
 
-    <div class="futuristic-shell">
+    <div class="futuristic-frame">
         <header class="futuristic-header">
             <div class="futuristic-identity">
                 <div class="futuristic-avatar">
@@ -32,50 +32,44 @@
                     <p class="futuristic-badge">{{ __('Futuristic Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
-                        <p class="futuristic-headline">{{ $data['headline'] }}</p>
+                        <p>{{ $data['headline'] }}</p>
+                    @endif
+                    @if ($data['location'])
+                        <p class="futuristic-location">{{ $data['location'] }}</p>
                     @endif
                 </div>
             </div>
-            @if ($data['location'])
-                <span class="futuristic-location">{{ $data['location'] }}</span>
+            @if (!empty($data['contacts']))
+                <ul class="futuristic-contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <li>{{ $contact }}</li>
+                    @endforeach
+                </ul>
             @endif
         </header>
 
-        <div class="futuristic-grid">
-            <aside class="futuristic-sidebar">
+        <main class="futuristic-body">
+            <section class="futuristic-grid">
                 @if ($data['summary'])
-                    <section class="futuristic-panel">
+                    <article class="futuristic-panel">
                         <h2>{{ __('Profile') }}</h2>
                         <p>{{ $data['summary'] }}</p>
-                    </section>
+                    </article>
                 @endif
-
-                @if (!empty($data['contacts']))
-                    <section class="futuristic-panel">
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul>
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
                 @if (!empty($data['skills']))
-                    <section class="futuristic-panel">
+                    <article class="futuristic-panel">
                         <h2>{{ __('Skills') }}</h2>
-                        <ul class="futuristic-tag-list">
+                        <ul>
                             @foreach ($data['skills'] as $skill)
                                 <li>{{ $skill }}</li>
                             @endforeach
                         </ul>
-                    </section>
+                    </article>
                 @endif
-
                 @if (!empty($data['languages']))
-                    <section class="futuristic-panel">
+                    <article class="futuristic-panel">
                         <h2>{{ __('Languages') }}</h2>
-                        <ul class="futuristic-language">
+                        <ul>
                             @foreach ($data['languages'] as $language)
                                 <li>
                                     <span>{{ $language['name'] }}</span>
@@ -85,79 +79,82 @@
                                 </li>
                             @endforeach
                         </ul>
-                    </section>
+                    </article>
                 @endif
-
                 @if (!empty($data['hobbies']))
-                    <section class="futuristic-panel">
+                    <article class="futuristic-panel">
                         <h2>{{ __('Interests') }}</h2>
-                        <ul class="futuristic-list">
+                        <ul>
                             @foreach ($data['hobbies'] as $hobby)
                                 <li>{{ $hobby }}</li>
                             @endforeach
                         </ul>
-                    </section>
+                    </article>
                 @endif
-            </aside>
+            </section>
 
-            <main class="futuristic-main">
-                @if (!empty($data['experiences']))
-                    <section class="futuristic-section">
-                        <h2>{{ __('Experience') }}</h2>
-                        <div class="futuristic-cards">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="futuristic-card">
+            @if (!empty($data['experiences']))
+                <section class="futuristic-section">
+                    <h2>{{ __('Experience Timeline') }}</h2>
+                    <div class="futuristic-timeline">
+                        @foreach ($data['experiences'] as $experience)
+                            <article>
+                                <div class="futuristic-timeline__marker"></div>
+                                <div class="futuristic-timeline__card">
                                     <header>
                                         <div>
-                                            <h3>{{ $experience['role'] }}</h3>
-                                            <p>{{ $experience['company'] }}</p>
+                                            @if ($experience['role'])
+                                                <h3>{{ $experience['role'] }}</h3>
+                                            @endif
+                                            <p>
+                                                {{ $experience['company'] }}
+                                                @if ($experience['company'] && $experience['location'])
+                                                    ·
+                                                @endif
+                                                {{ $experience['location'] }}
+                                            </p>
                                         </div>
                                         @if ($experience['period'])
                                             <span>{{ $experience['period'] }}</span>
                                         @endif
                                     </header>
-                                    @if ($experience['location'])
-                                        <p class="futuristic-meta">{{ $experience['location'] }}</p>
-                                    @endif
                                     @if ($experience['summary'])
-                                        <p class="futuristic-summary">{{ $experience['summary'] }}</p>
+                                        <p>{{ $experience['summary'] }}</p>
                                     @endif
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
+                                </div>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
 
-                @if (!empty($data['education']))
-                    <section class="futuristic-section">
-                        <h2>{{ __('Education') }}</h2>
-                        <div class="futuristic-table">
-                            @foreach ($data['education'] as $education)
-                                <article class="futuristic-row">
-                                    <div>
-                                        <h3>{{ $education['institution'] }}</h3>
-                                        @if ($education['degree'])
-                                            <p>{{ $education['degree'] }}</p>
-                                        @endif
-                                        @if ($education['field'])
-                                            <p>{{ $education['field'] }}</p>
-                                        @endif
-                                    </div>
-                                    <div class="futuristic-row__meta">
-                                        @if ($education['location'])
-                                            <span>{{ $education['location'] }}</span>
-                                        @endif
-                                        @if ($education['period'])
-                                            <span>{{ $education['period'] }}</span>
-                                        @endif
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-            </main>
-        </div>
+            @if (!empty($data['education']))
+                <section class="futuristic-section">
+                    <h2>{{ __('Education & Certifications') }}</h2>
+                    <div class="futuristic-education">
+                        @foreach ($data['education'] as $education)
+                            <article>
+                                <div class="futuristic-education__head">
+                                    <h3>{{ $education['institution'] }}</h3>
+                                    @if ($education['period'])
+                                        <span>{{ $education['period'] }}</span>
+                                    @endif
+                                </div>
+                                @if ($education['degree'])
+                                    <p>{{ $education['degree'] }}</p>
+                                @endif
+                                @if ($education['field'])
+                                    <p>{{ $education['field'] }}</p>
+                                @endif
+                                @if ($education['location'])
+                                    <p class="futuristic-education__meta">{{ $education['location'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
+        </main>
     </div>
 </body>
 </html>

--- a/resources/views/templates/gradient.blade.php
+++ b/resources/views/templates/gradient.blade.php
@@ -16,9 +16,9 @@
         $profileImage = $data['profile_image'] ?? null;
     @endphp
 
-    <div class="gradient-page">
-        <header class="gradient-header">
-            <div class="gradient-hero">
+    <div class="gradient-wrapper">
+        <header class="gradient-hero">
+            <div class="gradient-profile">
                 <div class="gradient-avatar">
                     @if ($profileImage)
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
@@ -29,42 +29,99 @@
                     @endif
                 </div>
                 <div>
-                    <p class="gradient-badge">{{ __('Gradient Resume') }}</p>
+                    <span class="gradient-badge">{{ __('Gradient Resume') }}</span>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
-                        <p class="gradient-headline">{{ $data['headline'] }}</p>
+                        <p>{{ $data['headline'] }}</p>
+                    @endif
+                    @if ($data['location'])
+                        <p class="gradient-location">{{ $data['location'] }}</p>
                     @endif
                 </div>
             </div>
-            @if ($data['location'])
-                <div class="gradient-location">{{ $data['location'] }}</div>
+            @if (!empty($data['contacts']))
+                <ul class="gradient-contact">
+                    @foreach ($data['contacts'] as $contact)
+                        <li>{{ $contact }}</li>
+                    @endforeach
+                </ul>
             @endif
         </header>
 
-        <div class="gradient-content">
-            <aside class="gradient-sidebar">
-                @if ($data['summary'])
-                    <section class="gradient-card gradient-card--highlight">
-                        <h2>{{ __('Profile') }}</h2>
-                        <p>{{ $data['summary'] }}</p>
+        <div class="gradient-columns">
+            <main class="gradient-main">
+                @if (!empty($data['experiences']))
+                    <section class="gradient-section">
+                        <h2>{{ __('Experience') }}</h2>
+                        <div class="gradient-grid">
+                            @foreach ($data['experiences'] as $experience)
+                                <article>
+                                    <header>
+                                        <div>
+                                            @if ($experience['role'])
+                                                <h3>{{ $experience['role'] }}</h3>
+                                            @endif
+                                            <p>
+                                                {{ $experience['company'] }}
+                                                @if ($experience['company'] && $experience['location'])
+                                                    ·
+                                                @endif
+                                                {{ $experience['location'] }}
+                                            </p>
+                                        </div>
+                                        @if ($experience['period'])
+                                            <span>{{ $experience['period'] }}</span>
+                                        @endif
+                                    </header>
+                                    @if ($experience['summary'])
+                                        <p>{{ $experience['summary'] }}</p>
+                                    @endif
+                                </article>
+                            @endforeach
+                        </div>
                     </section>
                 @endif
 
-                @if (!empty($data['contacts']))
-                    <section class="gradient-card">
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul>
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
+                @if (!empty($data['education']))
+                    <section class="gradient-section">
+                        <h2>{{ __('Education') }}</h2>
+                        <div class="gradient-education">
+                            @foreach ($data['education'] as $education)
+                                <article>
+                                    <header>
+                                        <h3>{{ $education['institution'] }}</h3>
+                                        @if ($education['period'])
+                                            <span>{{ $education['period'] }}</span>
+                                        @endif
+                                    </header>
+                                    @if ($education['degree'])
+                                        <p>{{ $education['degree'] }}</p>
+                                    @endif
+                                    @if ($education['field'])
+                                        <p>{{ $education['field'] }}</p>
+                                    @endif
+                                    @if ($education['location'])
+                                        <p class="gradient-meta">{{ $education['location'] }}</p>
+                                    @endif
+                                </article>
                             @endforeach
-                        </ul>
+                        </div>
+                    </section>
+                @endif
+            </main>
+
+            <aside class="gradient-aside">
+                @if ($data['summary'])
+                    <section class="gradient-card">
+                        <h2>{{ __('Profile') }}</h2>
+                        <p>{{ $data['summary'] }}</p>
                     </section>
                 @endif
 
                 @if (!empty($data['skills']))
                     <section class="gradient-card">
                         <h2>{{ __('Skills') }}</h2>
-                        <ul class="gradient-tag-list">
+                        <ul>
                             @foreach ($data['skills'] as $skill)
                                 <li>{{ $skill }}</li>
                             @endforeach
@@ -75,7 +132,7 @@
                 @if (!empty($data['languages']))
                     <section class="gradient-card">
                         <h2>{{ __('Languages') }}</h2>
-                        <ul class="gradient-language">
+                        <ul>
                             @foreach ($data['languages'] as $language)
                                 <li>
                                     <span>{{ $language['name'] }}</span>
@@ -91,7 +148,7 @@
                 @if (!empty($data['hobbies']))
                     <section class="gradient-card">
                         <h2>{{ __('Interests') }}</h2>
-                        <ul class="gradient-list">
+                        <ul>
                             @foreach ($data['hobbies'] as $hobby)
                                 <li>{{ $hobby }}</li>
                             @endforeach
@@ -99,64 +156,6 @@
                     </section>
                 @endif
             </aside>
-
-            <main class="gradient-main">
-                @if (!empty($data['experiences']))
-                    <section class="gradient-section">
-                        <h2>{{ __('Experience') }}</h2>
-                        <div class="gradient-experience">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="gradient-experience__item">
-                                    <div class="gradient-experience__header">
-                                        <div>
-                                            <h3>{{ $experience['role'] }}</h3>
-                                            <p>{{ $experience['company'] }}</p>
-                                        </div>
-                                        @if ($experience['period'])
-                                            <span class="gradient-chip">{{ $experience['period'] }}</span>
-                                        @endif
-                                    </div>
-                                    @if ($experience['location'])
-                                        <p class="gradient-meta">{{ $experience['location'] }}</p>
-                                    @endif
-                                    @if ($experience['summary'])
-                                        <p class="gradient-summary">{{ $experience['summary'] }}</p>
-                                    @endif
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-
-                @if (!empty($data['education']))
-                    <section class="gradient-section">
-                        <h2>{{ __('Education') }}</h2>
-                        <div class="gradient-education">
-                            @foreach ($data['education'] as $education)
-                                <article class="gradient-education__item">
-                                    <div>
-                                        <h3>{{ $education['institution'] }}</h3>
-                                        @if ($education['degree'])
-                                            <p>{{ $education['degree'] }}</p>
-                                        @endif
-                                        @if ($education['field'])
-                                            <p>{{ $education['field'] }}</p>
-                                        @endif
-                                    </div>
-                                    <div class="gradient-education__meta">
-                                        @if ($education['location'])
-                                            <span>{{ $education['location'] }}</span>
-                                        @endif
-                                        @if ($education['period'])
-                                            <span>{{ $education['period'] }}</span>
-                                        @endif
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-            </main>
         </div>
     </div>
 </body>

--- a/resources/views/templates/minimal.blade.php
+++ b/resources/views/templates/minimal.blade.php
@@ -18,7 +18,7 @@
 
     <div class="minimal-page">
         <header class="minimal-header">
-            <div class="minimal-header__identity">
+            <div class="minimal-identity">
                 <div class="minimal-avatar">
                     @if ($profileImage)
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
@@ -35,82 +35,34 @@
                     @endif
                 </div>
             </div>
-            <div class="minimal-header__meta">
-                <div class="minimal-badge">{{ __('Minimal Resume') }}</div>
-                @if ($data['location'])
-                    <span>{{ $data['location'] }}</span>
-                @endif
-            </div>
+            @if (!empty($data['contacts']))
+                <div class="minimal-contact">
+                    <h2>{{ __('Contact') }}</h2>
+                    <ul>
+                        @foreach ($data['contacts'] as $contact)
+                            <li>{{ $contact }}</li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endif
         </header>
 
-        <div class="minimal-columns">
-            <aside class="minimal-sidebar">
-                @if (!empty($data['contacts']))
-                    <section>
-                        <h2>{{ __('Contact') }}</h2>
-                        <ul>
-                            @foreach ($data['contacts'] as $contact)
-                                <li>{{ $contact }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
+        <main class="minimal-body">
+            @if ($data['summary'])
+                <section class="minimal-section minimal-section--summary">
+                    <h2>{{ __('Summary') }}</h2>
+                    <p>{{ $data['summary'] }}</p>
+                </section>
+            @endif
 
-                @if ($data['summary'])
-                    <section>
-                        <h2>{{ __('Summary') }}</h2>
-                        <p>{{ $data['summary'] }}</p>
-                    </section>
-                @endif
-
-                @if (!empty($data['skills']))
-                    <section>
-                        <h2>{{ __('Skills') }}</h2>
-                        <ul class="minimal-pill-list">
-                            @foreach ($data['skills'] as $skill)
-                                <li>{{ $skill }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
-                @if (!empty($data['languages']))
-                    <section>
-                        <h2>{{ __('Languages') }}</h2>
-                        <ul class="minimal-language-list">
-                            @foreach ($data['languages'] as $language)
-                                <li>
-                                    <span>{{ $language['name'] }}</span>
-                                    @if (!empty($language['level']))
-                                        <span>{{ ucfirst($language['level']) }}</span>
-                                    @endif
-                                </li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
-                @if (!empty($data['hobbies']))
-                    <section>
-                        <h2>{{ __('Interests') }}</h2>
-                        <ul class="minimal-list">
-                            @foreach ($data['hobbies'] as $hobby)
-                                <li>{{ $hobby }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-            </aside>
-
-            <main class="minimal-main">
-                @if (!empty($data['experiences']))
-                    <section class="minimal-section">
-                        <h2>{{ __('Experience') }}</h2>
-                        <div class="minimal-timeline">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="minimal-timeline__item">
-                                    <div class="minimal-timeline__bar"></div>
-                                    <div class="minimal-timeline__content">
+            @if (!empty($data['experiences']))
+                <section class="minimal-section">
+                    <h2>{{ __('Experience') }}</h2>
+                    <div class="minimal-timeline">
+                        @foreach ($data['experiences'] as $experience)
+                            <article>
+                                <header>
+                                    <div>
                                         @if ($experience['role'])
                                             <h3>{{ $experience['role'] }}</h3>
                                         @endif
@@ -121,49 +73,87 @@
                                             @endif
                                             {{ $experience['location'] }}
                                         </p>
-                                        @if ($experience['period'])
-                                            <span>{{ $experience['period'] }}</span>
-                                        @endif
-                                        @if ($experience['summary'])
-                                            <p class="minimal-note">{{ $experience['summary'] }}</p>
-                                        @endif
                                     </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
+                                    @if ($experience['period'])
+                                        <span>{{ $experience['period'] }}</span>
+                                    @endif
+                                </header>
+                                @if ($experience['summary'])
+                                    <p class="minimal-note">{{ $experience['summary'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
 
-                @if (!empty($data['education']))
-                    <section class="minimal-section">
-                        <h2>{{ __('Education') }}</h2>
-                        <ul class="minimal-list minimal-list--spaced">
-                            @foreach ($data['education'] as $education)
-                                <li>
-                                    <div>
-                                        <h3>{{ $education['institution'] }}</h3>
-                                        @if ($education['degree'])
-                                            <span>{{ $education['degree'] }}</span>
+            @if (!empty($data['education']))
+                <section class="minimal-section">
+                    <h2>{{ __('Education') }}</h2>
+                    <div class="minimal-education">
+                        @foreach ($data['education'] as $education)
+                            <article>
+                                <header>
+                                    <h3>{{ $education['institution'] }}</h3>
+                                    @if ($education['period'])
+                                        <span>{{ $education['period'] }}</span>
+                                    @endif
+                                </header>
+                                @if ($education['degree'])
+                                    <p>{{ $education['degree'] }}</p>
+                                @endif
+                                @if ($education['field'])
+                                    <p>{{ $education['field'] }}</p>
+                                @endif
+                                @if ($education['location'])
+                                    <p class="minimal-muted">{{ $education['location'] }}</p>
+                                @endif
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+            @endif
+
+            @if (!empty($data['skills']) || !empty($data['languages']) || !empty($data['hobbies']))
+                <section class="minimal-section minimal-section--grid">
+                    @if (!empty($data['skills']))
+                        <div class="minimal-card">
+                            <h2>{{ __('Skills') }}</h2>
+                            <ul>
+                                @foreach ($data['skills'] as $skill)
+                                    <li>{{ $skill }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                    @if (!empty($data['languages']))
+                        <div class="minimal-card">
+                            <h2>{{ __('Languages') }}</h2>
+                            <ul>
+                                @foreach ($data['languages'] as $language)
+                                    <li>
+                                        <span>{{ $language['name'] }}</span>
+                                        @if (!empty($language['level']))
+                                            <span>{{ ucfirst($language['level']) }}</span>
                                         @endif
-                                        @if ($education['field'])
-                                            <span>{{ $education['field'] }}</span>
-                                        @endif
-                                    </div>
-                                    <div class="minimal-list__meta">
-                                        @if ($education['location'])
-                                            <span>{{ $education['location'] }}</span>
-                                        @endif
-                                        @if ($education['period'])
-                                            <span>{{ $education['period'] }}</span>
-                                        @endif
-                                    </div>
-                                </li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-            </main>
-        </div>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                    @if (!empty($data['hobbies']))
+                        <div class="minimal-card">
+                            <h2>{{ __('Interests') }}</h2>
+                            <ul>
+                                @foreach ($data['hobbies'] as $hobby)
+                                    <li>{{ $hobby }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                </section>
+            @endif
+        </main>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add avatar handling and updated header layout for the classic template so contact and profile media always appear
- rebuild minimal, creative, corporate, gradient, dark mode, and futuristic templates with unique markup and CSS to emphasise different visual themes while showing all CV data
- refresh corresponding stylesheets to deliver distinct typography, backgrounds, and responsive behaviours for each theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d628751c0483329e1eba14c736651f