### PR TITLE
Revamp template preview cards

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -357,7 +357,7 @@
     }
 
     .createit-template-card__preview {
-        @apply relative h-48 bg-gradient-to-br;
+        @apply relative h-52 overflow-hidden rounded-t-[28px] bg-gradient-to-br;
     }
 
     .createit-template-card__badge {

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -5,46 +5,55 @@
                 'title' => 'Classic',
                 'description' => 'A timeless layout for any industry.',
                 'preview' => 'from-slate-200 via-white to-slate-100',
+                'partial' => 'templates.previews.classic',
             ],
             'modern' => [
                 'title' => 'Modern',
                 'description' => 'Bold typography with confident accents.',
                 'preview' => 'from-blue-200 via-blue-100 to-slate-50',
+                'partial' => 'templates.previews.modern',
             ],
             'creative' => [
                 'title' => 'Creative',
                 'description' => 'Playful composition for imaginative roles.',
                 'preview' => 'from-pink-200 via-purple-200 to-sky-100',
+                'partial' => 'templates.previews.creative',
             ],
             'minimal' => [
                 'title' => 'Minimal',
                 'description' => 'Crisp, airy layout that lets content breathe.',
                 'preview' => 'from-white via-slate-50 to-slate-100',
+                'partial' => 'templates.previews.minimal',
             ],
             'elegant' => [
                 'title' => 'Elegant',
                 'description' => 'Serif details and refined dividers.',
                 'preview' => 'from-amber-100 via-rose-50 to-white',
+                'partial' => 'templates.previews.elegant',
             ],
             'corporate' => [
                 'title' => 'Corporate',
                 'description' => 'Structured sections for senior roles.',
                 'preview' => 'from-slate-300 via-slate-200 to-white',
+                'partial' => 'templates.previews.corporate',
             ],
             'gradient' => [
                 'title' => 'Gradient',
                 'description' => 'Colourful blend that feels dynamic.',
                 'preview' => 'from-emerald-200 via-teal-200 to-cyan-100',
+                'partial' => 'templates.previews.gradient',
             ],
             'darkmode' => [
                 'title' => 'Dark Mode',
                 'description' => 'High-contrast styling that stands out.',
                 'preview' => 'from-slate-900 via-slate-800 to-black',
+                'partial' => 'templates.previews.darkmode',
             ],
             'futuristic' => [
                 'title' => 'Futuristic',
                 'description' => 'Tech inspired shapes and glow.',
                 'preview' => 'from-indigo-300 via-purple-300 to-slate-100',
+                'partial' => 'templates.previews.futuristic',
             ],
         ];
 
@@ -114,6 +123,7 @@
                         'title' => ucfirst($template),
                         'description' => 'Beautiful layout ready for your details.',
                         'preview' => 'from-slate-200 via-white to-slate-100',
+                        'partial' => 'templates.previews.classic',
                     ];
                     $previewId = 'template-preview-' . $template;
                     $previewSource = view('templates.' . $template, [
@@ -122,16 +132,9 @@
                 @endphp
                 <div class="group createit-template-card">
                     <div class="createit-template-card__preview bg-gradient-to-br {{ $meta['preview'] }}">
-                        <div class="absolute inset-0 flex items-center justify-center">
-                            <div class="w-40 rounded-2xl bg-white/80 p-4 shadow-xl shadow-slate-300/50">
-                                <div class="h-2 w-24 rounded-full bg-slate-200"></div>
-                                <div class="mt-3 space-y-2">
-                                    <div class="h-2 w-28 rounded-full bg-slate-300"></div>
-                                    <div class="h-2 w-32 rounded-full bg-slate-200"></div>
-                                    <div class="h-16 rounded-2xl border border-slate-100 bg-slate-50"></div>
-                                </div>
-                            </div>
-                        </div>
+                        @isset($meta['partial'])
+                            @include($meta['partial'])
+                        @endisset
                         <div class="createit-template-card__badge">
                             <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                             {{ __('Preview ready') }}

--- a/resources/views/templates/previews/classic.blade.php
+++ b/resources/views/templates/previews/classic.blade.php
@@ -1,0 +1,33 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-3 rounded-[22px] border border-slate-200/80 bg-white shadow-lg shadow-slate-200/70">
+        <div class="flex h-full">
+            <div class="flex w-2/5 flex-col gap-3 border-r border-slate-200/70 p-4">
+                <div class="h-14 w-14 rounded-xl border border-slate-200 bg-slate-100"></div>
+                <div class="space-y-2">
+                    <div class="h-2 w-20 rounded-full bg-slate-300"></div>
+                    <div class="h-2 w-16 rounded-full bg-slate-200"></div>
+                </div>
+                <div class="mt-auto space-y-2">
+                    <div class="h-2 w-24 rounded-full bg-slate-200"></div>
+                    <div class="h-2 w-20 rounded-full bg-slate-100"></div>
+                    <div class="h-2 w-[4.5rem] rounded-full bg-slate-100"></div>
+                </div>
+            </div>
+            <div class="flex flex-1 flex-col gap-4 p-4">
+                <div class="space-y-2">
+                    <div class="h-3 w-28 rounded-full bg-slate-200"></div>
+                    <div class="h-2 w-40 rounded-full bg-slate-100"></div>
+                </div>
+                <div class="space-y-2">
+                    <div class="h-2 w-full rounded-full bg-slate-100"></div>
+                    <div class="h-2 w-5/6 rounded-full bg-slate-100"></div>
+                    <div class="h-2 w-3/4 rounded-full bg-slate-100"></div>
+                </div>
+                <div class="mt-auto flex gap-3">
+                    <div class="h-12 flex-1 rounded-xl border border-slate-200 bg-slate-50"></div>
+                    <div class="h-12 flex-1 rounded-xl border border-slate-200 bg-slate-50"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/corporate.blade.php
+++ b/resources/views/templates/previews/corporate.blade.php
@@ -1,0 +1,44 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-3 rounded-[22px] border border-slate-300 bg-gradient-to-br from-slate-200 via-white to-slate-100 shadow-lg shadow-slate-300/40">
+        <div class="flex h-full flex-col gap-3 p-4">
+            <div class="flex items-center justify-between">
+                <div class="space-y-1">
+                    <div class="h-2.5 w-24 rounded-full bg-slate-500"></div>
+                    <div class="h-2 w-16 rounded-full bg-slate-400"></div>
+                </div>
+                <div class="h-10 w-10 rounded-xl border border-slate-300 bg-white"></div>
+            </div>
+            <div class="grid flex-1 grid-cols-[1.2fr,1fr] gap-3">
+                <div class="space-y-3 rounded-2xl border border-slate-200 bg-white/90 p-3">
+                    <div class="space-y-1">
+                        <div class="h-2 w-28 rounded-full bg-slate-400"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                    </div>
+                    <div class="space-y-1">
+                        <div class="h-2 w-24 rounded-full bg-slate-400"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                    </div>
+                </div>
+                <div class="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-3">
+                    <div class="space-y-1">
+                        <div class="h-2 w-20 rounded-full bg-slate-400"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                    </div>
+                    <div class="space-y-1">
+                        <div class="h-2 w-16 rounded-full bg-slate-400"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                        <div class="h-2 rounded-full bg-slate-200"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex gap-2">
+                <div class="h-2 flex-1 rounded-full bg-slate-300"></div>
+                <div class="h-2 flex-1 rounded-full bg-slate-200"></div>
+                <div class="h-2 flex-1 rounded-full bg-slate-200"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/creative.blade.php
+++ b/resources/views/templates/previews/creative.blade.php
@@ -1,0 +1,39 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 overflow-hidden rounded-[24px] bg-gradient-to-br from-purple-600/70 via-sky-500/60 to-pink-500/70 shadow-xl shadow-purple-500/30">
+        <div class="absolute -top-10 left-6 h-16 w-16 rounded-full bg-pink-300/50 blur-lg"></div>
+        <div class="absolute -bottom-12 right-4 h-24 w-24 rounded-full bg-sky-400/40 blur-2xl"></div>
+        <div class="absolute inset-3 rounded-[22px] border border-white/20 bg-slate-900/70 backdrop-blur">
+            <div class="flex h-full flex-col gap-3 p-4 text-white">
+                <div class="flex items-center gap-3">
+                    <div class="h-12 w-12 rounded-2xl bg-white/30"></div>
+                    <div class="space-y-1">
+                        <div class="h-2.5 w-20 rounded-full bg-white/60"></div>
+                        <div class="h-2 w-16 rounded-full bg-white/40"></div>
+                    </div>
+                </div>
+                <div class="grid flex-1 grid-cols-2 gap-3">
+                    <div class="space-y-2 rounded-2xl border border-white/15 bg-white/5 p-3">
+                        <div class="h-2 w-16 rounded-full bg-white/40"></div>
+                        <div class="grid gap-1">
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                        </div>
+                    </div>
+                    <div class="space-y-2 rounded-2xl border border-white/15 bg-white/5 p-3">
+                        <div class="h-2 w-14 rounded-full bg-white/40"></div>
+                        <div class="grid gap-1">
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                            <div class="h-2 rounded-full bg-white/20"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="flex gap-2">
+                    <div class="h-3 flex-1 rounded-full bg-gradient-to-r from-pink-400 via-purple-400 to-sky-400"></div>
+                    <div class="h-3 w-10 rounded-full bg-white/40"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/darkmode.blade.php
+++ b/resources/views/templates/previews/darkmode.blade.php
@@ -1,0 +1,35 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 rounded-[24px] border border-slate-700 bg-gradient-to-br from-slate-900 via-slate-950 to-black shadow-xl shadow-slate-900/50">
+        <div class="flex h-full flex-col gap-3 p-4 text-white">
+            <div class="flex items-center gap-3">
+                <div class="h-11 w-11 rounded-2xl border border-slate-700 bg-slate-800"></div>
+                <div class="space-y-1">
+                    <div class="h-2.5 w-24 rounded-full bg-slate-500"></div>
+                    <div class="h-2 w-16 rounded-full bg-slate-700"></div>
+                </div>
+            </div>
+            <div class="grid flex-1 grid-cols-[1fr,1.1fr] gap-3">
+                <div class="space-y-2 rounded-2xl border border-slate-800 bg-slate-900/70 p-3">
+                    <div class="h-2 w-20 rounded-full bg-slate-500"></div>
+                    <div class="space-y-1">
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                    </div>
+                </div>
+                <div class="space-y-2 rounded-2xl border border-slate-800 bg-slate-900/60 p-3">
+                    <div class="h-2 w-24 rounded-full bg-slate-500"></div>
+                    <div class="space-y-1">
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                        <div class="h-2 rounded-full bg-slate-800"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex gap-2">
+                <div class="h-3 flex-1 rounded-full bg-gradient-to-r from-blue-500 via-cyan-500 to-violet-500"></div>
+                <div class="h-3 w-12 rounded-full bg-slate-700"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/elegant.blade.php
+++ b/resources/views/templates/previews/elegant.blade.php
@@ -1,0 +1,43 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 rounded-[24px] border border-amber-200/70 bg-gradient-to-br from-rose-50 via-white to-amber-50 shadow-lg shadow-rose-200/40">
+        <div class="flex h-full flex-col gap-3 p-4 text-slate-800">
+            <div class="flex items-center gap-3">
+                <div class="h-12 w-12 rounded-full border border-amber-200 bg-amber-100"></div>
+                <div class="space-y-1">
+                    <div class="h-2.5 w-24 rounded-full bg-amber-200/80"></div>
+                    <div class="h-2 w-16 rounded-full bg-amber-100"></div>
+                </div>
+            </div>
+            <div class="grid flex-1 grid-cols-[1fr,1.2fr] gap-3">
+                <div class="space-y-3 rounded-2xl border border-amber-100 bg-white/80 p-3">
+                    <div class="space-y-2">
+                        <div class="h-2 w-20 rounded-full bg-amber-200/70"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                    </div>
+                    <div class="space-y-2">
+                        <div class="h-2 w-16 rounded-full bg-amber-200/70"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                    </div>
+                </div>
+                <div class="flex flex-col justify-between rounded-2xl border border-amber-100 bg-white/90 p-3">
+                    <div class="space-y-2">
+                        <div class="h-2 w-28 rounded-full bg-amber-200/70"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                    </div>
+                    <div class="space-y-2">
+                        <div class="h-2 w-24 rounded-full bg-amber-200/70"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                        <div class="h-2 rounded-full bg-amber-100"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex justify-end gap-2">
+                <div class="h-3 w-12 rounded-full bg-amber-200/80"></div>
+                <div class="h-3 w-20 rounded-full bg-amber-100"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/futuristic.blade.php
+++ b/resources/views/templates/previews/futuristic.blade.php
@@ -1,0 +1,39 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 overflow-hidden rounded-[24px] border border-cyan-400/50 bg-gradient-to-br from-slate-900 via-indigo-950 to-slate-950 shadow-2xl shadow-cyan-500/30">
+        <div class="absolute -top-10 right-0 h-24 w-24 rounded-full bg-cyan-500/40 blur-3xl"></div>
+        <div class="absolute -bottom-12 left-2 h-20 w-20 rounded-full bg-violet-500/40 blur-2xl"></div>
+        <div class="absolute inset-3 rounded-[22px] border border-cyan-500/30 bg-slate-900/70 backdrop-blur">
+            <div class="flex h-full flex-col gap-3 p-4 text-cyan-100">
+                <div class="flex items-center gap-3">
+                    <div class="h-12 w-12 rounded-2xl border border-cyan-400/60 bg-slate-900"></div>
+                    <div class="space-y-1">
+                        <div class="h-2.5 w-24 rounded-full bg-cyan-400"></div>
+                        <div class="h-2 w-16 rounded-full bg-violet-400/70"></div>
+                    </div>
+                </div>
+                <div class="grid flex-1 grid-cols-[1.2fr,1fr] gap-3">
+                    <div class="space-y-2 rounded-2xl border border-cyan-400/40 bg-slate-900/70 p-3">
+                        <div class="h-2 w-24 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400"></div>
+                        <div class="space-y-1">
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                        </div>
+                    </div>
+                    <div class="space-y-2 rounded-2xl border border-cyan-400/40 bg-slate-900/70 p-3">
+                        <div class="h-2 w-20 rounded-full bg-gradient-to-r from-cyan-400 to-violet-400"></div>
+                        <div class="space-y-1">
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                            <div class="h-2 rounded-full bg-slate-800"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="flex gap-2">
+                    <div class="h-3 flex-1 rounded-full bg-gradient-to-r from-cyan-400 via-blue-400 to-violet-400"></div>
+                    <div class="h-3 w-14 rounded-full bg-cyan-400/60"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/gradient.blade.php
+++ b/resources/views/templates/previews/gradient.blade.php
@@ -1,0 +1,37 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 overflow-hidden rounded-[24px] bg-gradient-to-br from-teal-300 via-sky-300 to-emerald-300 shadow-xl shadow-teal-400/30">
+        <div class="absolute inset-3 rounded-[22px] border border-white/30 bg-white/80 backdrop-blur">
+            <div class="flex h-full flex-col gap-3 p-4 text-slate-900">
+                <div class="flex items-center gap-3">
+                    <div class="h-12 w-12 rounded-2xl bg-gradient-to-br from-cyan-400 to-emerald-400"></div>
+                    <div class="space-y-1">
+                        <div class="h-2.5 w-24 rounded-full bg-emerald-400/70"></div>
+                        <div class="h-2 w-16 rounded-full bg-emerald-200/60"></div>
+                    </div>
+                </div>
+                <div class="grid flex-1 grid-cols-[1.3fr,1fr] gap-3">
+                    <div class="space-y-2 rounded-2xl border border-emerald-200/70 bg-white/70 p-3">
+                        <div class="h-2 w-24 rounded-full bg-emerald-300"></div>
+                        <div class="grid gap-1">
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                        </div>
+                    </div>
+                    <div class="space-y-2 rounded-2xl border border-emerald-200/70 bg-white/70 p-3">
+                        <div class="h-2 w-20 rounded-full bg-emerald-300"></div>
+                        <div class="grid gap-1">
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                            <div class="h-2 rounded-full bg-emerald-100"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="flex gap-3">
+                    <div class="h-2 flex-1 rounded-full bg-gradient-to-r from-teal-400 via-cyan-400 to-emerald-400"></div>
+                    <div class="h-2 w-12 rounded-full bg-emerald-200"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/minimal.blade.php
+++ b/resources/views/templates/previews/minimal.blade.php
@@ -1,0 +1,35 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-3 rounded-[22px] border border-slate-200 bg-white shadow-lg shadow-slate-200/60">
+        <div class="flex h-full flex-col gap-3 p-4">
+            <div class="flex items-center gap-3">
+                <div class="h-10 w-10 rounded-2xl border border-slate-200 bg-slate-100"></div>
+                <div class="space-y-1">
+                    <div class="h-2 w-24 rounded-full bg-slate-200"></div>
+                    <div class="h-2 w-16 rounded-full bg-slate-100"></div>
+                </div>
+            </div>
+            <div class="grid flex-1 grid-cols-2 gap-3">
+                <div class="space-y-2">
+                    <div class="h-2 w-16 rounded-full bg-slate-200"></div>
+                    <div class="space-y-1.5">
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                    </div>
+                </div>
+                <div class="space-y-2">
+                    <div class="h-2 w-14 rounded-full bg-slate-200"></div>
+                    <div class="space-y-1.5">
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                        <div class="h-2 rounded-full bg-slate-100"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="flex gap-2">
+                <div class="h-9 flex-1 rounded-xl border border-slate-200"></div>
+                <div class="h-9 flex-1 rounded-xl border border-slate-200"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/templates/previews/modern.blade.php
+++ b/resources/views/templates/previews/modern.blade.php
@@ -1,0 +1,32 @@
+<div aria-hidden="true" class="absolute inset-0">
+    <div class="absolute inset-2 flex rounded-[24px] bg-slate-950 text-white shadow-xl shadow-slate-900/60">
+        <div class="flex w-1/3 flex-col gap-3 rounded-l-[24px] bg-slate-900/80 p-4">
+            <div class="h-12 w-12 rounded-full bg-slate-700"></div>
+            <div class="space-y-2">
+                <div class="h-2 w-20 rounded-full bg-slate-500"></div>
+                <div class="h-2 w-16 rounded-full bg-slate-700"></div>
+            </div>
+            <div class="mt-auto grid gap-2">
+                <div class="h-2 rounded-full bg-slate-700"></div>
+                <div class="h-2 rounded-full bg-slate-800"></div>
+                <div class="h-2 rounded-full bg-slate-800"></div>
+            </div>
+        </div>
+        <div class="relative flex flex-1 flex-col gap-3 rounded-r-[24px] bg-white/95 p-4 text-slate-900">
+            <div class="absolute -top-8 right-6 h-14 w-14 rounded-2xl bg-sky-500/60 blur-xl"></div>
+            <div class="space-y-2">
+                <div class="h-2.5 w-32 rounded-full bg-slate-200"></div>
+                <div class="h-2 w-28 rounded-full bg-slate-100"></div>
+            </div>
+            <div class="grid gap-2">
+                <div class="h-2 rounded-full bg-slate-200"></div>
+                <div class="h-2 rounded-full bg-slate-100"></div>
+                <div class="h-2 rounded-full bg-slate-200"></div>
+            </div>
+            <div class="mt-auto flex gap-2">
+                <div class="h-10 flex-1 rounded-xl bg-sky-500/20"></div>
+                <div class="h-10 flex-1 rounded-xl bg-sky-500/10"></div>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- replace the generic template gallery previews with theme-specific partials so each card hints at its layout
- tweak the template card styling to better frame the new miniature previews

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d62dcbab948332bf83b4a9fa1a28ca