### PR TITLE
Enhance CV guide and profile aesthetics

### DIFF
--- a/resources/views/guide/cv.blade.php
+++ b/resources/views/guide/cv.blade.php
@@ -1,32 +1,153 @@
 <x-app-layout>
-    <div class="container mx-auto py-8">
-        <h1 class="text-3xl font-bold mb-6">CV Guide</h1>
+    <div class="relative isolate overflow-hidden bg-slate-950 text-white">
+        <div class="pointer-events-none absolute -top-32 right-4 h-72 w-72 rounded-full bg-indigo-500/40 blur-3xl"></div>
+        <div class="pointer-events-none absolute bottom-0 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-blue-400/30 blur-3xl"></div>
 
-        <p class="mb-4">
-            Creating a strong CV can help you stand out to employers. Here are some best practices:
-        </p>
-
-        <h2 class="text-xl font-semibold mt-4 mb-2">1. Keep it concise</h2>
-        <p>Limit your CV to one or two pages, highlighting only relevant information.</p>
-
-        <h2 class="text-xl font-semibold mt-4 mb-2">2. Focus on achievements</h2>
-        <p>Highlight accomplishments rather than just job responsibilities.</p>
-
-        <h2 class="text-xl font-semibold mt-4 mb-2">3. Use clear formatting</h2>
-        <p>Use headings, bullet points, and consistent fonts to make your CV readable.</p>
-
-        <h2 class="text-xl font-semibold mt-4 mb-2">4. Include key sections</h2>
-        <ul class="list-disc list-inside mb-4">
-            <li>Basic Information</li>
-            <li>Summary / Objective</li>
-            <li>Work Experience</li>
-            <li>Education</li>
-            <li>Skills</li>
-            <li>Additional Info (certifications, languages, etc.)</li>
-        </ul>
-
-        <p class="mt-6">
-            Ready to create your CV? <a href="{{ route('cv.create') }}" class="text-blue-600 hover:underline">Start here</a>.
-        </p>
+        <section class="relative mx-auto max-w-5xl px-6 py-20 text-center">
+            <p class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-indigo-200">
+                <span class="h-2 w-2 rounded-full bg-indigo-400"></span>
+                CV Mastery
+            </p>
+            <h1 class="mt-6 text-4xl font-semibold tracking-tight sm:text-5xl">Design a CV that tells your story beautifully</h1>
+            <p class="mx-auto mt-6 max-w-3xl text-base leading-relaxed text-slate-200 sm:text-lg">
+                A thoughtfully crafted CV is more than a list of roles — it is a curated narrative of your growth. Follow these curated guidelines to create a document that feels polished, modern, and uniquely yours.
+            </p>
+            <div class="mt-10 flex flex-wrap justify-center gap-4">
+                <a href="{{ route('cv.create') }}" class="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-indigo-500/20 transition hover:-translate-y-0.5 hover:shadow-xl">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                    </svg>
+                    Start crafting your CV
+                </a>
+                <a href="#best-practices" class="inline-flex items-center gap-2 rounded-full border border-white/60 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/10">
+                    Explore tips
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0-6.75 6.75M19.5 12l-6.75-6.75" />
+                    </svg>
+                </a>
+            </div>
+        </section>
     </div>
+
+    <section id="best-practices" class="bg-slate-100">
+        <div class="mx-auto max-w-5xl space-y-16 px-6 py-16">
+            <div class="grid gap-8 md:grid-cols-3">
+                <article class="group rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl">
+                    <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-blue-500 text-white shadow-lg shadow-indigo-500/20">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75h7.5m-7.5 3.75h7.5M4.5 5.25A2.25 2.25 0 0 1 6.75 3h10.5A2.25 2.25 0 0 1 19.5 5.25v13.5L12 15.75 4.5 18.75z" />
+                        </svg>
+                    </div>
+                    <h2 class="mt-6 text-xl font-semibold text-slate-900">Lead with clarity</h2>
+                    <p class="mt-4 text-sm text-slate-600">
+                        Keep your CV concise and purposeful. Stick to one or two pages and ensure every section supports your story.
+                    </p>
+                </article>
+
+                <article class="group rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl">
+                    <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-purple-500 to-indigo-500 text-white shadow-lg shadow-indigo-500/20">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 9.75 7.5 4.5v15l9-5.25" />
+                        </svg>
+                    </div>
+                    <h2 class="mt-6 text-xl font-semibold text-slate-900">Showcase achievements</h2>
+                    <p class="mt-4 text-sm text-slate-600">
+                        Focus on measurable wins. Use active verbs and data points so recruiters quickly see the value you created.
+                    </p>
+                </article>
+
+                <article class="group rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl">
+                    <div class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-500 to-blue-500 text-white shadow-lg shadow-cyan-500/20">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15l3.75-4.5M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+                        </svg>
+                    </div>
+                    <h2 class="mt-6 text-xl font-semibold text-slate-900">Polish the layout</h2>
+                    <p class="mt-4 text-sm text-slate-600">
+                        Embrace generous spacing, consistent fonts, and clear headings. A clean structure makes your CV effortless to read.
+                    </p>
+                </article>
+            </div>
+
+            <div class="grid gap-8 lg:grid-cols-[1.1fr,0.9fr]">
+                <div class="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-900/5">
+                    <h2 class="text-2xl font-semibold text-slate-900">Essential sections to include</h2>
+                    <p class="mt-4 text-sm text-slate-600">
+                        Craft each section with intention. Use bullet points to surface the highlights and keep paragraphs short.
+                    </p>
+                    <ul class="mt-6 grid gap-4 text-sm text-slate-700 sm:grid-cols-2">
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Basic information &amp; personal branding headline
+                        </li>
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Concise professional summary that frames your value
+                        </li>
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Experience focused on outcomes, scope, and impact
+                        </li>
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Education, certifications, and relevant training
+                        </li>
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Technical, creative, and interpersonal skills
+                        </li>
+                        <li class="flex items-start gap-3 rounded-2xl bg-slate-50 p-4">
+                            <span class="mt-1 h-2.5 w-2.5 rounded-full bg-indigo-500"></span>
+                            Optional extras: awards, languages, volunteering
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="flex flex-col justify-between rounded-3xl border border-indigo-200 bg-gradient-to-br from-indigo-500 via-indigo-500 to-blue-500 p-8 text-white shadow-xl shadow-indigo-500/30">
+                    <div>
+                        <h2 class="text-2xl font-semibold">Finishing touches that stand out</h2>
+                        <ul class="mt-6 space-y-4 text-sm text-indigo-50">
+                            <li class="flex items-start gap-3">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="mt-0.5 h-5 w-5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                                </svg>
+                                Tailor your summary and keywords for each role you apply to.
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="mt-0.5 h-5 w-5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15l3.75-4.5m6-2.25a9 9 0 1 1-18 0 9 9 0 0 1 18 0z" />
+                                </svg>
+                                Proofread carefully; refined language leaves a lasting impression.
+                            </li>
+                            <li class="flex items-start gap-3">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="mt-0.5 h-5 w-5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l3 3" />
+                                </svg>
+                                Keep formatting simple so applicant tracking systems (ATS) read it flawlessly.
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="mt-8 rounded-2xl bg-white/15 p-6 text-sm backdrop-blur">
+                        <p class="font-semibold uppercase tracking-wide text-indigo-200">Quick tip</p>
+                        <p class="mt-3 text-indigo-50">
+                            Save your CV as a PDF to preserve layout and typography across devices, and name the file professionally (e.g., <em>firstname_lastname_cv.pdf</em>).
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="rounded-3xl border border-slate-200 bg-white p-10 text-center shadow-lg shadow-slate-900/5">
+                <h2 class="text-3xl font-semibold text-slate-900">Ready to shine?</h2>
+                <p class="mx-auto mt-4 max-w-2xl text-sm text-slate-600">
+                    Start with these building blocks, then tailor the tone to match your personality and the industry you are targeting. A confident, well-structured CV makes it easy for recruiters to say yes.
+                </p>
+                <a href="{{ route('cv.create') }}" class="mt-8 inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:-translate-y-0.5 hover:bg-slate-800">
+                    Launch the CV builder
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12h15m0 0-6.75 6.75M19.5 12l-6.75-6.75" />
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </section>
 </x-app-layout>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,25 +1,65 @@
 <x-app-layout>
-    
+    <div class="relative isolate overflow-hidden bg-slate-950 text-white">
+        <div class="pointer-events-none absolute -left-24 top-0 h-80 w-80 rounded-full bg-indigo-500/40 blur-3xl"></div>
+        <div class="pointer-events-none absolute bottom-[-10rem] right-0 h-96 w-96 rounded-full bg-blue-500/20 blur-3xl"></div>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.update-profile-information-form')
+        <section class="relative mx-auto max-w-6xl px-6 py-20">
+            <p class="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-indigo-200">
+                <span class="h-2 w-2 rounded-full bg-indigo-400"></span>
+                Account hub
+            </p>
+            <div class="mt-8 grid gap-8 lg:grid-cols-[1.25fr,0.75fr] lg:items-end">
+                <div class="space-y-5">
+                    <h1 class="text-4xl font-semibold tracking-tight sm:text-5xl">Manage your profile with confidence</h1>
+                    <p class="max-w-2xl text-base text-slate-200 sm:text-lg">
+                        Keep your personal details, security credentials, and privacy preferences up to date. A refreshed profile keeps recruiters informed and protects your account.
+                    </p>
+                    <div class="flex flex-wrap items-center gap-3 text-sm">
+                        <span class="inline-flex items-center gap-2 rounded-full bg-indigo-500/30 px-4 py-2 font-medium">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25a8.25 8.25 0 1 1 15 0v.75H4.5v-.75Z" />
+                            </svg>
+                            {{ $user->name }}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 font-medium text-slate-100">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25 12 13.5l9-5.25M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
+                            </svg>
+                            {{ $user->email }}
+                        </span>
+                        <span class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 font-medium text-slate-100">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 8.25v3.75l2.25 2.25m6-2.25a8.25 8.25 0 1 1-16.5 0 8.25 8.25 0 0 1 16.5 0Z" />
+                            </svg>
+                            Member since {{ optional($user->created_at)->format('M Y') ?? '—' }}
+                        </span>
+                    </div>
+                </div>
+                <div class="rounded-3xl border border-white/20 bg-white/10 p-8 backdrop-blur">
+                    <h2 class="text-sm font-semibold uppercase tracking-wide text-indigo-200">Need a refresh?</h2>
+                    <p class="mt-3 text-sm text-slate-100">
+                        Review your details frequently to ensure your applications and saved templates stay aligned with your latest experience.
+                    </p>
+                    <div class="mt-6 flex flex-wrap gap-3 text-xs font-semibold uppercase tracking-wide text-slate-100">
+                        <span class="rounded-full bg-white/10 px-3 py-1">Contact details</span>
+                        <span class="rounded-full bg-white/10 px-3 py-1">Security</span>
+                        <span class="rounded-full bg-white/10 px-3 py-1">Privacy</span>
+                    </div>
                 </div>
             </div>
+        </section>
+    </div>
 
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.update-password-form')
-                </div>
+    <section class="bg-slate-100 pb-16">
+        <div class="mx-auto -mt-16 max-w-6xl space-y-10 px-6">
+            <div class="grid gap-8 lg:grid-cols-2">
+                @include('profile.partials.update-profile-information-form')
+                @include('profile.partials.update-password-form')
             </div>
 
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.delete-user-form')
-                </div>
+            <div>
+                @include('profile.partials.delete-user-form')
             </div>
         </div>
-    </div>
+    </section>
 </x-app-layout>

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,29 +1,45 @@
-<section class="space-y-6">
-    <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Delete Account') }}
-        </h2>
-
-        <p class="mt-1 text-sm text-gray-600">
-            {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
-        </p>
+<section class="rounded-3xl border border-rose-200/70 bg-white/95 p-8 shadow-xl shadow-rose-200/40 backdrop-blur">
+    <header class="flex flex-col gap-4 border-b border-rose-100 pb-6 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-start gap-4">
+            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-rose-500 to-orange-500 text-white shadow-lg shadow-rose-500/40">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12v-.008ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                </svg>
+            </span>
+            <div>
+                <h2 class="text-xl font-semibold text-slate-900">
+                    {{ __('Delete Account') }}
+                </h2>
+                <p class="mt-2 text-sm text-slate-600">
+                    {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
+                </p>
+            </div>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-rose-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-rose-600">
+            {{ __('Irreversible') }}
+        </span>
     </header>
 
-    <x-danger-button
-        x-data=""
-        x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
-    >{{ __('Delete Account') }}</x-danger-button>
+    <div class="mt-8 flex flex-wrap items-center gap-3">
+        <x-danger-button
+            x-data=""
+            x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
+        >{{ __('Delete Account') }}</x-danger-button>
+        <p class="text-xs text-rose-500">
+            {{ __('This action cannot be undone.') }}
+        </p>
+    </div>
 
     <x-modal name="confirm-user-deletion" :show="$errors->userDeletion->isNotEmpty()" focusable>
         <form method="post" action="{{ route('profile.destroy') }}" class="p-6">
             @csrf
             @method('delete')
 
-            <h2 class="text-lg font-medium text-gray-900">
+            <h2 class="text-lg font-semibold text-slate-900">
                 {{ __('Are you sure you want to delete your account?') }}
             </h2>
 
-            <p class="mt-1 text-sm text-gray-600">
+            <p class="mt-3 text-sm text-slate-600">
                 {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
             </p>
 
@@ -34,14 +50,14 @@
                     id="password"
                     name="password"
                     type="password"
-                    class="mt-1 block w-3/4"
+                    class="mt-1 block w-full rounded-2xl border-slate-300 focus:border-rose-500 focus:ring-rose-500"
                     placeholder="{{ __('Password') }}"
                 />
 
                 <x-input-error :messages="$errors->userDeletion->get('password')" class="mt-2" />
             </div>
 
-            <div class="mt-6 flex justify-end">
+            <div class="mt-8 flex flex-wrap justify-end gap-3">
                 <x-secondary-button x-on:click="$dispatch('close')">
                     {{ __('Cancel') }}
                 </x-secondary-button>

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -1,37 +1,48 @@
-<section>
-    <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Update Password') }}
-        </h2>
-
-        <p class="mt-1 text-sm text-gray-600">
-            {{ __('Ensure your account is using a long, random password to stay secure.') }}
-        </p>
+<section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-xl shadow-slate-900/5 backdrop-blur">
+    <header class="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-start gap-4">
+            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-violet-500 to-indigo-500 text-white shadow-lg shadow-indigo-500/30">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 0 0-9 0v3.75m-1.5 0h12a1.5 1.5 0 0 1 1.5 1.5v6.75a1.5 1.5 0 0 1-1.5 1.5h-12a1.5 1.5 0 0 1-1.5-1.5v-6.75a1.5 1.5 0 0 1 1.5-1.5Z" />
+                </svg>
+            </span>
+            <div>
+                <h2 class="text-xl font-semibold text-slate-900">
+                    {{ __('Update Password') }}
+                </h2>
+                <p class="mt-2 text-sm text-slate-600">
+                    {{ __('Ensure your account is using a long, random password to stay secure.') }}
+                </p>
+            </div>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-violet-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-violet-600">
+            {{ __('Security') }}
+        </span>
     </header>
 
-    <form method="post" action="{{ route('password.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('password.update') }}" class="mt-8 grid gap-6">
         @csrf
         @method('put')
 
         <div>
-            <x-input-label for="update_password_current_password" :value="__('Current Password')" />
-            <x-text-input id="update_password_current_password" name="current_password" type="password" class="mt-1 block w-full" autocomplete="current-password" />
+            <x-input-label for="update_password_current_password" :value="__('Current Password')" class="text-sm font-semibold text-slate-700" />
+            <x-text-input id="update_password_current_password" name="current_password" type="password" class="mt-2 block w-full" autocomplete="current-password" />
             <x-input-error :messages="$errors->updatePassword->get('current_password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="update_password_password" :value="__('New Password')" />
-            <x-text-input id="update_password_password" name="password" type="password" class="mt-1 block w-full" autocomplete="new-password" />
+            <x-input-label for="update_password_password" :value="__('New Password')" class="text-sm font-semibold text-slate-700" />
+            <x-text-input id="update_password_password" name="password" type="password" class="mt-2 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="update_password_password_confirmation" :value="__('Confirm Password')" />
-            <x-text-input id="update_password_password_confirmation" name="password_confirmation" type="password" class="mt-1 block w-full" autocomplete="new-password" />
+            <x-input-label for="update_password_password_confirmation" :value="__('Confirm Password')" class="text-sm font-semibold text-slate-700" />
+            <x-text-input id="update_password_password_confirmation" name="password_confirmation" type="password" class="mt-2 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password_confirmation')" class="mt-2" />
         </div>
 
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-3">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
             @if (session('status') === 'password-updated')
@@ -40,7 +51,7 @@
                     x-show="show"
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm text-gray-600"
+                    class="text-sm font-medium text-emerald-600"
                 >{{ __('Saved.') }}</p>
             @endif
         </div>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,45 +1,59 @@
-<section>
-    <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Profile Information') }}
-        </h2>
-
-        <p class="mt-1 text-sm text-gray-600">
-            {{ __("Update your account's profile information and email address.") }}
-        </p>
+<section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-xl shadow-slate-900/5 backdrop-blur">
+    <header class="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-start gap-4">
+            <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 to-blue-500 text-white shadow-lg shadow-indigo-500/30">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-6 w-6">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.25a8.25 8.25 0 1 1 15 0v.75H4.5v-.75Z" />
+                </svg>
+            </span>
+            <div>
+                <h2 class="text-xl font-semibold text-slate-900">
+                    {{ __('Profile Information') }}
+                </h2>
+                <p class="mt-2 text-sm text-slate-600">
+                    {{ __("Update your account's profile information and email address.") }}
+                </p>
+            </div>
+        </div>
+        <span class="inline-flex items-center rounded-full bg-indigo-50 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-indigo-600">
+            {{ __('Personal details') }}
+        </span>
     </header>
 
     <form id="send-verification" method="post" action="{{ route('verification.send') }}">
         @csrf
     </form>
 
-    <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('profile.update') }}" class="mt-8 grid gap-6 sm:grid-cols-2">
         @csrf
         @method('patch')
 
-        <div>
-            <x-input-label for="name" :value="__('Name')" />
-            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)" required autofocus autocomplete="name" />
+        <div class="sm:col-span-1">
+            <x-input-label for="name" :value="__('Name')" class="text-sm font-semibold text-slate-700" />
+            <x-text-input id="name" name="name" type="text" class="mt-2 block w-full" :value="old('name', $user->name)" required autofocus autocomplete="name" />
             <x-input-error class="mt-2" :messages="$errors->get('name')" />
         </div>
 
-        <div>
-            <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
+        <div class="sm:col-span-1">
+            <x-input-label for="email" :value="__('Email')" class="text-sm font-semibold text-slate-700" />
+            <x-text-input id="email" name="email" type="email" class="mt-2 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
-                <div>
-                    <p class="text-sm mt-2 text-gray-800">
+                <div class="mt-4 rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                    <p class="font-medium">
                         {{ __('Your email address is unverified.') }}
-
-                        <button form="send-verification" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                            {{ __('Click here to re-send the verification email.') }}
-                        </button>
                     </p>
 
+                    <button form="send-verification" class="mt-2 inline-flex items-center gap-2 rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-2 focus:ring-offset-amber-100">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25 12 13.5l9-5.25M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
+                        </svg>
+                        {{ __('Click here to re-send the verification email.') }}
+                    </button>
+
                     @if (session('status') === 'verification-link-sent')
-                        <p class="mt-2 font-medium text-sm text-green-600">
+                        <p class="mt-2 font-medium text-amber-700">
                             {{ __('A new verification link has been sent to your email address.') }}
                         </p>
                     @endif
@@ -47,7 +61,7 @@
             @endif
         </div>
 
-        <div class="flex items-center gap-4">
+        <div class="flex flex-wrap items-center gap-3 sm:col-span-2">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
             @if (session('status') === 'profile-updated')
@@ -56,7 +70,7 @@
                     x-show="show"
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm text-gray-600"
+                    class="text-sm font-medium text-emerald-600"
                 >{{ __('Saved.') }}</p>
             @endif
         </div>


### PR DESCRIPTION
## Summary
- Redesign the CV guide with a gradient hero, feature cards, and polished guidance sections
- Refresh the profile dashboard with an immersive hero banner and glassmorphism-inspired cards
- Update profile management forms with icon headers, richer feedback messaging, and cohesive styling

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6369f7c288332899e8d0c0c2c512c