### PR TITLE
Send password reset emails synchronously

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\Notification;
 
 class User extends Authenticatable
 {
@@ -53,5 +55,13 @@ class User extends Authenticatable
     public function cvs(): HasMany
     {
         return $this->hasMany(Cv::class);
+    }
+
+    /**
+     * Send the password reset notification immediately instead of queueing it.
+     */
+    public function sendPasswordResetNotification($token): void
+    {
+        Notification::sendNow($this, new ResetPassword($token));
     }
 }

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -3,6 +3,7 @@
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
 
 test('reset password link screen can be rendered', function () {
     $response = $this->get('/forgot-password');
@@ -57,4 +58,18 @@ test('password can be reset with valid token', function () {
 
         return true;
     });
+});
+
+test('password reset notification bypasses the queue', function () {
+    config(['queue.default' => 'database']);
+
+    Notification::fake();
+    Queue::fake();
+
+    $user = User::factory()->create();
+
+    $user->sendPasswordResetNotification('example-token');
+
+    Notification::assertSentTo($user, ResetPassword::class);
+    Queue::assertNothingPushed();
 });


### PR DESCRIPTION
## Summary
- send password reset notifications immediately to avoid relying on a background queue for forgotten password emails
- add a regression test to ensure the password reset notification bypasses the queue

## Testing
- not run (composer install requires a GitHub token in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68da1bbc5ed88332b78c23f1d7831334