### PR TITLE
Send password reset emails synchronously

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Support\Facades\Notification;
 
 class User extends Authenticatable
 {
@@ -62,6 +61,6 @@ class User extends Authenticatable
      */
     public function sendPasswordResetNotification($token): void
     {
-        Notification::sendNow($this, new ResetPassword($token));
+        $this->notifyNow(new ResetPassword($token));
     }
 }


### PR DESCRIPTION
## Summary
- replace the Notification facade call with the built-in notifyNow helper so password reset notices send immediately
- remove the unused Notification facade import from the User model

## Testing
- not run (composer install fails: requires external network access)


------
https://chatgpt.com/codex/tasks/task_e_68da1e3f833c8332b818c5e4402d3786