### PR TITLE
Allow CV history template downloads and improve photo uploads

### DIFF
--- a/resources/js/cv-form.js
+++ b/resources/js/cv-form.js
@@ -162,6 +162,34 @@ const initCvForm = () => {
     const allowedPhotoTypes = ['image/jpeg', 'image/png', 'image/webp'];
     const maxPhotoSizeBytes = 2 * 1024 * 1024;
 
+    const matchesImageExtension = (fileName) => {
+        if (!fileName || typeof fileName !== 'string') {
+            return false;
+        }
+
+        return /\.(jpe?g|png|webp|gif|bmp|tiff?|heic|heif|svg)$/i.test(fileName);
+    };
+
+    const isAllowedPhotoType = (file) => {
+        if (!file) {
+            return false;
+        }
+
+        if (file.type && file.type.startsWith('image/')) {
+            return true;
+        }
+
+        if (file.type && allowedPhotoTypes.includes(file.type)) {
+            return true;
+        }
+
+        if (file.name && matchesImageExtension(file.name)) {
+            return true;
+        }
+
+        return false;
+    };
+
     const revokeCurrentPhotoObjectUrl = () => {
         if (currentPhotoObjectUrl) {
             URL.revokeObjectURL(currentPhotoObjectUrl);
@@ -219,8 +247,8 @@ const initCvForm = () => {
             return true;
         }
 
-        if (file.type && !allowedPhotoTypes.includes(file.type)) {
-            applyPhotoError('Please upload a JPG, PNG, or WEBP image.');
+        if (!isAllowedPhotoType(file)) {
+            applyPhotoError('Please upload an image file (JPG, PNG, WebP, HEIC, GIF, etc.).');
             validateStep(1, { report: false });
             return false;
         }

--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -424,8 +424,8 @@
                                         <span class="px-2 text-center text-xs text-slate-400 {{ $profileImageUrl ? 'hidden' : '' }}" data-photo-preview-placeholder>{{ __('No photo yet') }}</span>
                                     </div>
                                     <div class="flex-1">
-                                        <input type="file" name="profile_image" accept="image/jpeg,image/png,image/webp" class="{{ $fileInputClasses }} @error('profile_image') border-red-500 focus:border-red-500 focus:ring-red-200 @enderror">
-                                        <p class="mt-2 text-xs text-slate-500">{{ __('Upload a JPG, PNG, or WEBP image. Max 2 MB.') }}</p>
+                                        <input type="file" name="profile_image" accept="image/*" class="{{ $fileInputClasses }} @error('profile_image') border-red-500 focus:border-red-500 focus:ring-red-200 @enderror">
+                                        <p class="mt-2 text-xs text-slate-500">{{ __('Upload any image file (JPG, PNG, WebP, HEIC, etc.). Max 2 MB.') }}</p>
                                         <p data-photo-error class="mt-2 text-sm text-red-600 hidden"></p>
                                         @error('profile_image')
                                             <p class="mt-2 text-sm text-red-600">{{ $message }}</p>

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -340,7 +340,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col gap-3 pt-2">
-                            <a href="{{ route('cv.download', $templateKey) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-slate-400/40 transition hover:-translate-y-0.5 hover:bg-black">
+                            <a href="{{ route('cv.download', array_filter(['template' => $templateKey, 'cv' => request('cv')])) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-slate-400/40 transition hover:-translate-y-0.5 hover:bg-black">
                                 {{ __('Download PDF') }}
                                 <span aria-hidden="true">&darr;</span>
                             </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/history','history')->name('cv.history');
         Route::get('/{cv}/edit','edit')->name('cv.edit');
         Route::put('/{cv}','update')->name('cv.update');
+        Route::patch('/{cv}/template','updateTemplate')->name('cv.update-template');
         Route::delete('/{cv}','destroy')->name('cv.destroy');
         Route::get('/preview','preview')->name('cv.preview');
         Route::get('/guide','guide')->name('cv.guide');
@@ -45,7 +46,7 @@ Route::middleware('auth')->group(function () {
 
 Route::prefix('cv')->controller(CvController::class)->group(function () {
     Route::get('/templates','templates')->name('cv.templates');
-    Route::get('/download/{template}','download')->name('cv.download');
+    Route::get('/download','download')->name('cv.download');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- prefill the new CV form with the most recent details and expose template updates/downloads directly from history
- broaden profile photo upload support with richer client-side validation and ensure preview/download links carry template context
- refactor the download endpoint to accept query parameters for template selection across the app

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da3a1086c48332949c1a4ae906903e