### PR TITLE
Allow auth pages to scroll vertically

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -3,7 +3,8 @@
         @apply font-sans antialiased bg-gradient-to-br from-slate-100 via-white to-slate-200 text-slate-900;
         min-height: 100vh;
         position: relative;
-        overflow: hidden;
+        overflow-x: hidden;
+        overflow-y: auto;
     }
 
     .createit-auth__background {


### PR DESCRIPTION
## Summary
- allow the guest layout body to scroll vertically by only hiding horizontal overflow
- ensure login and register cards remain accessible on smaller screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dba8004ef883329555cf37b87ba18b