### PR TITLE
Update favicon to use CreateIt logo

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="createit-gradient" x1="10" y1="6" x2="40" y2="42" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#8B5CF6" />
+      <stop offset="0.5" stop-color="#6366F1" />
+      <stop offset="1" stop-color="#14B8A6" />
+    </linearGradient>
+    <linearGradient id="createit-spark" x1="35" y1="8" x2="42" y2="15" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FDE68A" />
+      <stop offset="1" stop-color="#F97316" />
+    </linearGradient>
+  </defs>
+  <circle cx="24" cy="24" r="22" fill="url(#createit-gradient)" opacity="0.15" />
+  <path d="M34.5 14.8c-2.8-3.6-7.1-5.8-11.8-5.8-8.4 0-15.2 6.8-15.2 15.2s6.8 15.2 15.2 15.2c4.9 0 9.3-2.3 12.1-6.1l-3.5-2.4c-2 2.8-5.1 4.5-8.6 4.5-5.8 0-10.6-4.7-10.6-10.6S16.9 14 22.7 14c3.4 0 6.4 1.7 8.4 4.3l3.4-3.5z" fill="url(#createit-gradient)" />
+  <path d="M39.5 9.2l1.6 3.8 3.8 1.6-3.8 1.6-1.6 3.8-1.6-3.8-3.8-1.6 3.8-1.6 1.6-3.8z" fill="url(#createit-spark)" />
+</svg>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name','CreateIt') }}</title>
+    <link rel="icon" type="image/svg+xml" href="{{ asset('favicon.svg') }}">
+    <link rel="alternate icon" href="{{ asset('favicon.ico') }}">
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body class="antialiased bg-slate-100 text-slate-900">

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -7,6 +7,9 @@
 
         <title>{{ config('app.name', 'CreateIt') }}</title>
 
+        <link rel="icon" type="image/svg+xml" href="{{ asset('favicon.svg') }}">
+        <link rel="alternate icon" href="{{ asset('favicon.ico') }}">
+
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- add a CreateIt logo SVG favicon to the public assets
- reference the new favicon from the authenticated and guest layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcbd14927083328a2b2ab33f3997f7