### PR TITLE
Add avatar rendering to PDF resume templates

### DIFF
--- a/resources/views/cv/pdf/layout.blade.php
+++ b/resources/views/cv/pdf/layout.blade.php
@@ -34,6 +34,23 @@
     $templateKey = in_array($template ?? '', $availableTemplates, true) ? $template : 'classic';
 
     $fullName = trim((string) (($data['first_name'] ?? '') . ' ' . ($data['last_name'] ?? '')));
+    $initials = collect([
+            $data['first_name'] ?? null,
+            $data['last_name'] ?? null,
+        ])
+        ->filter(fn ($item) => is_string($item) && trim($item) !== '')
+        ->map(fn ($item) => mb_strtoupper(mb_substr(trim($item), 0, 1)))
+        ->implode('');
+
+    if ($initials === '' && $fullName !== '') {
+        $initials = collect(preg_split('/\s+/u', $fullName))
+            ->filter(fn ($segment) => is_string($segment) && trim($segment) !== '')
+            ->map(fn ($segment) => mb_strtoupper(mb_substr(trim($segment), 0, 1)))
+            ->take(2)
+            ->implode('');
+    }
+
+    $initials = $initials !== '' ? $initials : null;
     $headline = trim((string) ($data['headline'] ?? '')) ?: null;
     $summary = trim((string) ($data['summary'] ?? '')) ?: null;
 
@@ -193,6 +210,7 @@
     'languages' => $languages,
     'hobbies' => $hobbies,
     'profileImage' => $profileImage,
+    'initials' => $initials,
     'accentColor' => $accentColor ?? '#1e293b',
     'templateKey' => $templateKey,
 ])

--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -14,6 +14,33 @@
         padding-bottom: 18px;
         margin-bottom: 22px;
     }
+    .template-classic .classic-header-main {
+        display: flex;
+        align-items: center;
+        gap: 20px;
+    }
+    .template-classic .classic-avatar {
+        width: 78px;
+        height: 78px;
+        border-radius: 999px;
+        border: 3px solid {{ $accentColor }};
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(15, 23, 42, 0.05);
+        color: {{ $accentColor }};
+    }
+    .template-classic .classic-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-classic .classic-avatar-initials {
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+    }
     .template-classic .classic-name {
         font-size: 26px;
         font-weight: 600;
@@ -85,10 +112,23 @@
 </style>
 <div class="classic-wrapper">
     <header class="classic-header">
-        <h1 class="classic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-        @if ($headline)
-            <p class="classic-headline">{{ strtoupper($headline) }}</p>
-        @endif
+        <div class="classic-header-main">
+            @if ($profileImage || $initials)
+                <div class="classic-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="classic-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
+            @endif
+            <div>
+                <h1 class="classic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="classic-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
+        </div>
     </header>
     <div class="classic-layout">
         <main>

--- a/resources/views/cv/pdf/templates/corporate.blade.php
+++ b/resources/views/cv/pdf/templates/corporate.blade.php
@@ -19,6 +19,29 @@
         display: grid;
         gap: 24px;
     }
+    .template-corporate .corporate-avatar {
+        width: 86px;
+        height: 86px;
+        border-radius: 999px;
+        border: 3px solid rgba(148, 163, 184, 0.4);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(15, 23, 42, 0.6);
+        color: #f8fafc;
+        margin-bottom: 18px;
+    }
+    .template-corporate .corporate-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-corporate .corporate-avatar-initials {
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: 0.2em;
+    }
     .template-corporate .corporate-name {
         font-size: 24px;
         font-weight: 600;
@@ -73,6 +96,15 @@
 <div class="corporate-wrapper">
     <aside class="corporate-sidebar">
         <div>
+            @if ($profileImage || $initials)
+                <div class="corporate-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="corporate-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
+            @endif
             <h1 class="corporate-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
             @if ($headline)
                 <p class="corporate-headline">{{ strtoupper($headline) }}</p>

--- a/resources/views/cv/pdf/templates/creative.blade.php
+++ b/resources/views/cv/pdf/templates/creative.blade.php
@@ -20,8 +20,35 @@
     .template-creative .creative-avatar {
         display: flex;
         flex-direction: column;
-        gap: 12px;
+        gap: 16px;
         align-items: flex-start;
+    }
+    .template-creative .creative-avatar-block {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+    }
+    .template-creative .creative-avatar-figure {
+        width: 88px;
+        height: 88px;
+        border-radius: 28px;
+        background: rgba(15, 23, 42, 0.18);
+        border: 3px solid rgba(255, 255, 255, 0.55);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #ffffff;
+    }
+    .template-creative .creative-avatar-figure img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-creative .creative-avatar-initials {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: 0.3em;
     }
     .template-creative .creative-name {
         font-size: 30px;
@@ -120,10 +147,23 @@
     <div class="creative-top">
         <div class="creative-avatar">
             <span class="creative-pill">{{ strtoupper($templateKey ?? 'Creative') }}</span>
-            <h1 class="creative-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="creative-headline">{{ strtoupper($headline) }}</p>
-            @endif
+            <div class="creative-avatar-block">
+                @if ($profileImage || $initials)
+                    <div class="creative-avatar-figure">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @else
+                            <span class="creative-avatar-initials">{{ $initials }}</span>
+                        @endif
+                    </div>
+                @endif
+                <div>
+                    <h1 class="creative-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                    @if ($headline)
+                        <p class="creative-headline">{{ strtoupper($headline) }}</p>
+                    @endif
+                </div>
+            </div>
         </div>
         @if (!empty($contactItems))
             <div class="creative-contact">

--- a/resources/views/cv/pdf/templates/darkmode.blade.php
+++ b/resources/views/cv/pdf/templates/darkmode.blade.php
@@ -17,6 +17,33 @@
         align-items: flex-start;
         margin-bottom: 28px;
     }
+    .template-darkmode .dark-header-main {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+    }
+    .template-darkmode .dark-avatar {
+        width: 86px;
+        height: 86px;
+        border-radius: 999px;
+        border: 3px solid rgba(56, 189, 248, 0.6);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(15, 118, 110, 0.35);
+        color: #e2e8f0;
+    }
+    .template-darkmode .dark-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-darkmode .dark-avatar-initials {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: 0.3em;
+    }
     .template-darkmode .dark-name {
         font-size: 28px;
         font-weight: 600;
@@ -94,11 +121,22 @@
 </style>
 <div class="dark-wrapper">
     <header class="dark-header">
-        <div>
-            <h1 class="dark-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="dark-headline">{{ strtoupper($headline) }}</p>
+        <div class="dark-header-main">
+            @if ($profileImage || $initials)
+                <div class="dark-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="dark-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
             @endif
+            <div>
+                <h1 class="dark-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="dark-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
         </div>
         @if (!empty($contactItems))
             <div class="dark-contact">

--- a/resources/views/cv/pdf/templates/elegant.blade.php
+++ b/resources/views/cv/pdf/templates/elegant.blade.php
@@ -20,6 +20,28 @@
         display: grid;
         gap: 24px;
     }
+    .template-elegant .elegant-portrait {
+        width: 92px;
+        height: 92px;
+        border-radius: 30px;
+        background: rgba(255, 255, 255, 0.15);
+        border: 3px solid rgba(255, 255, 255, 0.45);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 18px;
+        color: #fdf4ff;
+    }
+    .template-elegant .elegant-portrait img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-elegant .elegant-portrait-initials {
+        font-size: 22px;
+        letter-spacing: 0.4em;
+    }
     .template-elegant .elegant-name {
         font-size: 26px;
         letter-spacing: 0.08em;
@@ -84,6 +106,15 @@
 <div class="elegant-wrapper">
     <aside class="elegant-sidebar">
         <div>
+            @if ($profileImage || $initials)
+                <div class="elegant-portrait">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="elegant-portrait-initials">{{ $initials }}</span>
+                    @endif
+                </div>
+            @endif
             <div class="elegant-badge">Profile</div>
             <h1 class="elegant-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
             @if ($headline)

--- a/resources/views/cv/pdf/templates/futuristic.blade.php
+++ b/resources/views/cv/pdf/templates/futuristic.blade.php
@@ -16,6 +16,33 @@
         align-items: flex-start;
         margin-bottom: 30px;
     }
+    .template-futuristic .futuristic-header-main {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+    }
+    .template-futuristic .futuristic-avatar {
+        width: 88px;
+        height: 88px;
+        border-radius: 28px;
+        border: 3px solid rgba(124, 58, 237, 0.6);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: radial-gradient(circle at center, rgba(168, 85, 247, 0.3), rgba(30, 64, 175, 0.35));
+        color: #f5f3ff;
+    }
+    .template-futuristic .futuristic-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-futuristic .futuristic-avatar-initials {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: 0.35em;
+    }
     .template-futuristic .futuristic-name {
         font-size: 30px;
         font-weight: 600;
@@ -104,11 +131,22 @@
 </style>
 <div class="futuristic-wrapper">
     <header class="futuristic-header">
-        <div>
-            <h1 class="futuristic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="futuristic-headline">{{ strtoupper($headline) }}</p>
+        <div class="futuristic-header-main">
+            @if ($profileImage || $initials)
+                <div class="futuristic-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="futuristic-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
             @endif
+            <div>
+                <h1 class="futuristic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="futuristic-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
         </div>
         @if (!empty($contactItems))
             <div class="futuristic-contact">

--- a/resources/views/cv/pdf/templates/gradient.blade.php
+++ b/resources/views/cv/pdf/templates/gradient.blade.php
@@ -16,6 +16,33 @@
         align-items: flex-start;
         margin-bottom: 26px;
     }
+    .template-gradient .gradient-header-main {
+        display: flex;
+        align-items: center;
+        gap: 22px;
+    }
+    .template-gradient .gradient-avatar {
+        width: 82px;
+        height: 82px;
+        border-radius: 24px;
+        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(16, 185, 129, 0.28));
+        border: 3px solid rgba(14, 165, 233, 0.35);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #0f172a;
+    }
+    .template-gradient .gradient-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-gradient .gradient-avatar-initials {
+        font-size: 20px;
+        font-weight: 600;
+        letter-spacing: 0.28em;
+    }
     .template-gradient .gradient-name {
         font-size: 27px;
         font-weight: 600;
@@ -97,12 +124,23 @@
 </style>
 <div class="gradient-wrapper">
     <header class="gradient-header">
-        <div>
-            <div class="gradient-badge">Profile</div>
-            <h1 class="gradient-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="gradient-headline">{{ strtoupper($headline) }}</p>
+        <div class="gradient-header-main">
+            @if ($profileImage || $initials)
+                <div class="gradient-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="gradient-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
             @endif
+            <div>
+                <div class="gradient-badge">Profile</div>
+                <h1 class="gradient-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="gradient-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
         </div>
         @if (!empty($contactItems))
             <div class="gradient-contact">

--- a/resources/views/cv/pdf/templates/minimal.blade.php
+++ b/resources/views/cv/pdf/templates/minimal.blade.php
@@ -9,6 +9,33 @@
     .template-minimal .minimal-header {
         margin-bottom: 26px;
     }
+    .template-minimal .minimal-header-main {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+    }
+    .template-minimal .minimal-avatar {
+        width: 74px;
+        height: 74px;
+        border-radius: 999px;
+        border: 2px solid rgba(100, 116, 139, 0.3);
+        background: rgba(15, 23, 42, 0.05);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #0f172a;
+    }
+    .template-minimal .minimal-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-minimal .minimal-avatar-initials {
+        font-size: 20px;
+        font-weight: 500;
+        letter-spacing: 0.22em;
+    }
     .template-minimal .minimal-name {
         font-size: 28px;
         font-weight: 500;
@@ -83,10 +110,23 @@
 </style>
 <div class="minimal-wrapper">
     <header class="minimal-header">
-        <h1 class="minimal-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-        @if ($headline)
-            <p class="minimal-headline">{{ strtoupper($headline) }}</p>
-        @endif
+        <div class="minimal-header-main">
+            @if ($profileImage || $initials)
+                <div class="minimal-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="minimal-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
+            @endif
+            <div>
+                <h1 class="minimal-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="minimal-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
+        </div>
         @if (!empty($contactItems))
             <div class="minimal-contact">
                 @foreach ($contactItems as $contact)

--- a/resources/views/cv/pdf/templates/modern.blade.php
+++ b/resources/views/cv/pdf/templates/modern.blade.php
@@ -14,6 +14,33 @@
         color: #ffffff;
         padding: 28px 32px;
     }
+    .template-modern .modern-header-top {
+        display: flex;
+        align-items: center;
+        gap: 24px;
+    }
+    .template-modern .modern-avatar {
+        width: 84px;
+        height: 84px;
+        border-radius: 999px;
+        border: 3px solid rgba(255, 255, 255, 0.55);
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(15, 23, 42, 0.2);
+        color: #ffffff;
+    }
+    .template-modern .modern-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+    .template-modern .modern-avatar-initials {
+        font-size: 22px;
+        font-weight: 600;
+        letter-spacing: 0.18em;
+    }
     .template-modern .modern-name {
         font-size: 28px;
         font-weight: 600;
@@ -99,10 +126,23 @@
 </style>
 <div class="modern-wrapper">
     <header class="modern-header">
-        <h1 class="modern-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-        @if ($headline)
-            <p class="modern-headline">{{ strtoupper($headline) }}</p>
-        @endif
+        <div class="modern-header-top">
+            @if ($profileImage || $initials)
+                <div class="modern-avatar">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @else
+                        <span class="modern-avatar-initials">{{ $initials }}</span>
+                    @endif
+                </div>
+            @endif
+            <div>
+                <h1 class="modern-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                @if ($headline)
+                    <p class="modern-headline">{{ strtoupper($headline) }}</p>
+                @endif
+            </div>
+        </div>
         @if (!empty($contactItems))
             <div class="modern-contact">
                 @foreach ($contactItems as $contact)


### PR DESCRIPTION
## Summary
- derive user initials in the shared PDF layout and pass them to template views
- refresh each themed PDF template header with avatar support that matches its visual style

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd45f9a4083329567fac2174ba297