### PR TITLE
Fix profile image handling in templates

### DIFF
--- a/app/View/TemplateDataBuilder.php
+++ b/app/View/TemplateDataBuilder.php
@@ -257,9 +257,14 @@ class TemplateDataBuilder
         $profileImage = $value('profile_image');
         if (is_string($profileImage) && trim($profileImage) !== '') {
             $profileImage = trim($profileImage);
-            if (!filter_var($profileImage, FILTER_VALIDATE_URL)) {
+            $isAbsoluteUrl = filter_var($profileImage, FILTER_VALIDATE_URL) !== false;
+            $isStorageLike = str_starts_with($profileImage, '/storage/') || str_starts_with($profileImage, 'storage/');
+
+            if ($isStorageLike && !$isAbsoluteUrl) {
+                $profileImage = '/' . ltrim($profileImage, '/');
+            } elseif (!$isAbsoluteUrl) {
                 try {
-                    $profileImage = Storage::disk('public')->url($profileImage);
+                    $profileImage = Storage::disk('public')->url(ltrim($profileImage, '/'));
                 } catch (\Throwable $e) {
                     $profileImage = null;
                 }

--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -113,13 +113,9 @@
 <div class="classic-wrapper">
     <header class="classic-header">
         <div class="classic-header-main">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="classic-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="classic-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/cv/pdf/templates/corporate.blade.php
+++ b/resources/views/cv/pdf/templates/corporate.blade.php
@@ -96,13 +96,9 @@
 <div class="corporate-wrapper">
     <aside class="corporate-sidebar">
         <div>
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="corporate-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="corporate-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <h1 class="corporate-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>

--- a/resources/views/cv/pdf/templates/creative.blade.php
+++ b/resources/views/cv/pdf/templates/creative.blade.php
@@ -148,13 +148,9 @@
         <div class="creative-avatar">
             <span class="creative-pill">{{ strtoupper($templateKey ?? 'Creative') }}</span>
             <div class="creative-avatar-block">
-                @if ($profileImage || $initials)
+                @if ($profileImage)
                     <div class="creative-avatar-figure">
-                        @if ($profileImage)
-                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @else
-                            <span class="creative-avatar-initials">{{ $initials }}</span>
-                        @endif
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                     </div>
                 @endif
                 <div>

--- a/resources/views/cv/pdf/templates/darkmode.blade.php
+++ b/resources/views/cv/pdf/templates/darkmode.blade.php
@@ -122,13 +122,9 @@
 <div class="dark-wrapper">
     <header class="dark-header">
         <div class="dark-header-main">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="dark-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="dark-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/cv/pdf/templates/elegant.blade.php
+++ b/resources/views/cv/pdf/templates/elegant.blade.php
@@ -106,13 +106,9 @@
 <div class="elegant-wrapper">
     <aside class="elegant-sidebar">
         <div>
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="elegant-portrait">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="elegant-portrait-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div class="elegant-badge">Profile</div>

--- a/resources/views/cv/pdf/templates/futuristic.blade.php
+++ b/resources/views/cv/pdf/templates/futuristic.blade.php
@@ -132,13 +132,9 @@
 <div class="futuristic-wrapper">
     <header class="futuristic-header">
         <div class="futuristic-header-main">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="futuristic-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="futuristic-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/cv/pdf/templates/gradient.blade.php
+++ b/resources/views/cv/pdf/templates/gradient.blade.php
@@ -125,13 +125,9 @@
 <div class="gradient-wrapper">
     <header class="gradient-header">
         <div class="gradient-header-main">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="gradient-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="gradient-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/cv/pdf/templates/minimal.blade.php
+++ b/resources/views/cv/pdf/templates/minimal.blade.php
@@ -111,13 +111,9 @@
 <div class="minimal-wrapper">
     <header class="minimal-header">
         <div class="minimal-header-main">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="minimal-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="minimal-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/cv/pdf/templates/modern.blade.php
+++ b/resources/views/cv/pdf/templates/modern.blade.php
@@ -127,13 +127,9 @@
 <div class="modern-wrapper">
     <header class="modern-header">
         <div class="modern-header-top">
-            @if ($profileImage || $initials)
+            @if ($profileImage)
                 <div class="modern-avatar">
-                    @if ($profileImage)
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @else
-                        <span class="modern-avatar-initials">{{ $initials }}</span>
-                    @endif
+                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
                 </div>
             @endif
             <div>

--- a/resources/views/templates/classic.blade.php
+++ b/resources/views/templates/classic.blade.php
@@ -59,15 +59,9 @@
     <div class="page">
         <header class="page-header">
             <div class="header-main">
-                @if ($profileImage || $initials !== '')
+                @if ($profileImage)
                     <div class="portrait">
-                        @if ($profileImage)
-                            <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                        @elseif ($initials !== '')
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
+                        <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
                     </div>
                 @endif
                 <div class="hero-text">

--- a/resources/views/templates/corporate.blade.php
+++ b/resources/views/templates/corporate.blade.php
@@ -19,15 +19,11 @@
     <div class="corporate-wrapper">
         <header class="corporate-topbar">
             <div class="corporate-brand">
-                <div class="corporate-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="corporate-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <p class="corporate-badge">{{ __('Corporate Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>

--- a/resources/views/templates/creative.blade.php
+++ b/resources/views/templates/creative.blade.php
@@ -19,15 +19,11 @@
     <div class="creative-canvas">
         <header class="creative-banner">
             <div class="creative-nameplate">
-                <div class="creative-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="creative-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <p class="creative-badge">{{ __('Creative Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>

--- a/resources/views/templates/darkmode.blade.php
+++ b/resources/views/templates/darkmode.blade.php
@@ -19,15 +19,11 @@
     <div class="darkmode-shell">
         <header class="darkmode-header">
             <div class="darkmode-identity">
-                <div class="darkmode-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="darkmode-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <p class="darkmode-badge">{{ __('Dark Mode Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>

--- a/resources/views/templates/elegant.blade.php
+++ b/resources/views/templates/elegant.blade.php
@@ -19,15 +19,11 @@
     <div class="elegant-page">
         <header class="elegant-header">
             <div class="elegant-header__info">
-                <div class="elegant-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="elegant-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])

--- a/resources/views/templates/futuristic.blade.php
+++ b/resources/views/templates/futuristic.blade.php
@@ -19,15 +19,11 @@
     <div class="futuristic-frame">
         <header class="futuristic-header">
             <div class="futuristic-identity">
-                <div class="futuristic-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="futuristic-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <p class="futuristic-badge">{{ __('Futuristic Resume') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>

--- a/resources/views/templates/gradient.blade.php
+++ b/resources/views/templates/gradient.blade.php
@@ -19,15 +19,11 @@
     <div class="gradient-wrapper">
         <header class="gradient-hero">
             <div class="gradient-profile">
-                <div class="gradient-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="gradient-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div>
                     <span class="gradient-badge">{{ __('Gradient Resume') }}</span>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>

--- a/resources/views/templates/minimal.blade.php
+++ b/resources/views/templates/minimal.blade.php
@@ -22,15 +22,11 @@
             <header class="minimal-header">
                 <div class="minimal-header-bar">
                     <div class="minimal-identity">
-                        <div class="minimal-avatar">
-                            @if ($profileImage)
+                        @if ($profileImage)
+                            <div class="minimal-avatar">
                                 <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                            @elseif ($initials !== '')
-                                <span>{{ $initials }}</span>
-                            @else
-                                <span>{{ __('CV') }}</span>
-                            @endif
-                        </div>
+                            </div>
+                        @endif
                         <div>
                             <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                             @if ($data['headline'])

--- a/resources/views/templates/modern.blade.php
+++ b/resources/views/templates/modern.blade.php
@@ -19,15 +19,11 @@
     <div class="modern-page">
         <aside class="modern-sidebar">
             <div class="modern-profile-card">
-                <div class="modern-avatar">
-                    @if ($profileImage)
+                @if ($profileImage)
+                    <div class="modern-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
-                    @elseif ($initials !== '')
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
+                    </div>
+                @endif
                 <div class="modern-profile-text">
                     <h1 class="modern-name">{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])


### PR DESCRIPTION
## Summary
- normalise stored profile image values so template rendering preserves uploaded photos
- render avatar blocks in HTML and PDF templates only when a photo exists to avoid empty placeholders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df70b993108332ad96769160d2b8a0