### PR TITLE
Handle missing profile photos gracefully

### DIFF
--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -232,8 +232,17 @@
             if (filter_var($candidate, FILTER_VALIDATE_URL)) {
                 $profileImageUrl = $candidate;
             } else {
+                $storagePath = preg_replace('#^/?storage/#', '', $candidate);
+                $storagePath = ltrim((string) $storagePath, '/');
+
                 try {
-                    $profileImageUrl = \Illuminate\Support\Facades\Storage::disk('public')->url($candidate);
+                    if ($storagePath !== '' && \Illuminate\Support\Facades\Storage::disk('public')->exists($storagePath)) {
+                        $profileImageUrl = \Illuminate\Support\Facades\Storage::disk('public')->url($storagePath);
+                    } elseif (\Illuminate\Support\Facades\Storage::disk('public')->exists(ltrim($candidate, '/'))) {
+                        $profileImageUrl = \Illuminate\Support\Facades\Storage::disk('public')->url(ltrim($candidate, '/'));
+                    } else {
+                        $profileImageUrl = null;
+                    }
                 } catch (\Throwable $e) {
                     $profileImageUrl = null;
                 }

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -186,6 +186,28 @@
                 $linkedin = is_string($cvData['linkedin'] ?? null) ? trim($cvData['linkedin']) : null;
                 $github = is_string($cvData['github'] ?? null) ? trim($cvData['github']) : null;
                 $profileImage = is_string($cvData['profile_image'] ?? null) ? trim($cvData['profile_image']) : null;
+                if ($profileImage === '') {
+                    $profileImage = null;
+                }
+                if ($profileImage) {
+                    $isAbsoluteProfileUrl = filter_var($profileImage, FILTER_VALIDATE_URL) !== false;
+                    if (! $isAbsoluteProfileUrl) {
+                        $storagePath = preg_replace('#^/?storage/#', '', $profileImage);
+                        $storagePath = ltrim((string) $storagePath, '/');
+
+                        try {
+                            if ($storagePath !== '' && \Illuminate\Support\Facades\Storage::disk('public')->exists($storagePath)) {
+                                $profileImage = \Illuminate\Support\Facades\Storage::disk('public')->url($storagePath);
+                            } elseif (\Illuminate\Support\Facades\Storage::disk('public')->exists(ltrim($profileImage, '/'))) {
+                                $profileImage = \Illuminate\Support\Facades\Storage::disk('public')->url(ltrim($profileImage, '/'));
+                            } else {
+                                $profileImage = null;
+                            }
+                        } catch (\Throwable $e) {
+                            $profileImage = null;
+                        }
+                    }
+                }
 
                 $socialLinks = collect([
                     ['label' => 'Website', 'url' => $website],


### PR DESCRIPTION
## Summary
- validate stored profile image paths when preparing template data so missing files don't render broken images
- guard the prefilled profile photo preview in the form and dashboard overview to hide images that no longer exist

## Testing
- php artisan test *(fails: missing vendor directory in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df7350ea9c83329f089061b132edf2