### PR TITLE
Revamp PDF templates with print-friendly layouts

### DIFF
--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -1,237 +1,359 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $hasClassicAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-classic {
-        background: #f8fafc;
+    body.template-classic {
+        background-color: #f5f1eb;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
+        color: #2f2a1e;
     }
-    .template-classic .classic-wrapper {
-        width: 100%;
-        background: #ffffff;
-        border: 1px solid #e2e8f0;
+
+    body.template-classic .classic-page {
+        background-color: #ffffff;
+        border: 2px solid #d9c7a3;
         border-radius: 18px;
-        padding: 28px;
+        padding: 26px 30px 30px;
+        box-shadow: none;
     }
-    .template-classic .classic-header {
-        border-bottom: 2px solid {{ $accentColor }};
-        padding-bottom: 18px;
-        margin-bottom: 22px;
-    }
-    .template-classic .classic-header-main {
-        display: flex;
-        align-items: center;
-        gap: 20px;
-    }
-    .template-classic .classic-avatar {
-        width: 78px;
-        height: 78px;
-        border-radius: 999px;
-        border: 3px solid {{ $accentColor }};
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: rgba(15, 23, 42, 0.05);
-        color: {{ $accentColor }};
-    }
-    .template-classic .classic-avatar img {
+
+    body.template-classic .classic-header {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+        margin-bottom: 24px;
+    }
+
+    body.template-classic .classic-header td {
+        vertical-align: top;
+    }
+
+    body.template-classic .classic-avatar {
+        width: 96px;
+        height: 96px;
+        border-radius: 54px;
+        border: 3px solid #c59d5f;
+        background-color: #f6ede1;
+        overflow: hidden;
+    }
+
+    body.template-classic .classic-avatar img {
+        width: 96px;
+        height: 96px;
         object-fit: cover;
     }
-    .template-classic .classic-avatar-initials {
-        font-size: 20px;
-        font-weight: 600;
-        letter-spacing: 0.18em;
+
+    body.template-classic .classic-avatar span {
+        display: block;
+        width: 96px;
+        height: 96px;
+        line-height: 96px;
+        text-align: center;
+        font-size: 24px;
+        letter-spacing: 6px;
+        color: #b07233;
     }
-    .template-classic .classic-name {
-        font-size: 26px;
-        font-weight: 600;
-        letter-spacing: 0.02em;
-        color: #0f172a;
-    }
-    .template-classic .classic-headline {
-        font-size: 13px;
+
+    body.template-classic .classic-name {
+        font-size: 28px;
+        letter-spacing: 4px;
         text-transform: uppercase;
-        letter-spacing: 0.32em;
-        color: {{ $accentColor }};
+        color: #2f2a1e;
+    }
+
+    body.template-classic .classic-headline {
         margin-top: 6px;
-    }
-    .template-classic .classic-layout {
-        display: grid;
-        grid-template-columns: 2.2fr 1fr;
-        gap: 28px;
-    }
-    .template-classic .classic-contact {
-        display: grid;
-        gap: 8px;
-        font-size: 11px;
-        color: #475569;
-    }
-    .template-classic .classic-section-title {
-        font-size: 14px;
-        font-weight: 600;
+        font-size: 12px;
+        letter-spacing: 4px;
         text-transform: uppercase;
-        letter-spacing: 0.28em;
-        color: {{ $accentColor }};
-        margin-bottom: 10px;
+        color: #b07233;
     }
-    .template-classic .classic-item {
-        margin-bottom: 18px;
+
+    body.template-classic .classic-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
     }
-    .template-classic .classic-item:last-child {
+
+    body.template-classic .classic-contact li {
+        font-size: 11px;
+        color: #5b5043;
+        margin-bottom: 4px;
+    }
+
+    body.template-classic .classic-summary {
+        background-color: #faf4ea;
+        border: 1px solid #e9dcc7;
+        border-radius: 14px;
+        padding: 16px 18px;
+        margin-bottom: 24px;
+        font-size: 12px;
+        color: #42392f;
+    }
+
+    body.template-classic .classic-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-classic .classic-summary p:last-child {
         margin-bottom: 0;
     }
-    .template-classic .classic-item h3 {
-        font-size: 13px;
-        font-weight: 600;
-        color: #1e293b;
-        margin-bottom: 4px;
+
+    body.template-classic .classic-columns {
+        width: 100%;
+        border-collapse: collapse;
     }
-    .template-classic .classic-meta {
-        font-size: 11px;
-        color: #64748b;
-        margin-bottom: 4px;
+
+    body.template-classic .classic-columns td {
+        vertical-align: top;
     }
-    .template-classic .classic-summary {
+
+    body.template-classic .classic-main {
+        width: 65%;
+        padding-right: 18px;
+        border-right: 1px solid #e6ddcf;
+    }
+
+    body.template-classic .classic-aside {
+        width: 35%;
+        padding-left: 18px;
+    }
+
+    body.template-classic .classic-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-classic .classic-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-classic .classic-section-title {
         font-size: 12px;
-        color: #334155;
-        margin-bottom: 20px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: #b07233;
+        margin-bottom: 10px;
     }
-    .template-classic .classic-taglist {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
+
+    body.template-classic .classic-entry {
+        margin-bottom: 18px;
     }
-    .template-classic .classic-tag {
-        background: rgba(148, 163, 184, 0.2);
+
+    body.template-classic .classic-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-classic .classic-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #2f2a1e;
+    }
+
+    body.template-classic .classic-entry-meta {
+        font-size: 11px;
+        color: #5b5043;
+        margin-top: 4px;
+    }
+
+    body.template-classic .classic-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-classic .classic-bullets li {
+        font-size: 12px;
+        color: #42392f;
+        margin-bottom: 6px;
+    }
+
+    body.template-classic .classic-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-classic .classic-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-classic .classic-chip-list li {
+        display: inline-block;
+        background-color: #f0e4d3;
+        border: 1px solid #e3d2b8;
         border-radius: 999px;
         padding: 4px 10px;
         font-size: 10px;
+        letter-spacing: 2px;
         text-transform: uppercase;
-        letter-spacing: 0.18em;
-        color: #475569;
+        color: #6c5840;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-classic .classic-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-classic .classic-simple-list li {
+        font-size: 11px;
+        color: #3f372d;
+        margin-bottom: 6px;
+    }
+
+    body.template-classic .classic-simple-list li span {
+        color: #8c7b66;
     }
 </style>
-<div class="classic-wrapper">
-    <header class="classic-header">
-        <div class="classic-header-main">
-            @if ($profileImage)
+
+<div class="classic-page">
+    <table class="classic-header">
+        <tr>
+            <td style="width: 110px;">
                 <div class="classic-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @if ($profileImage)
+                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                    @elseif ($initials)
+                        <span>{{ $initials }}</span>
+                    @else
+                        <span>{{ __('CV') }}</span>
+                    @endif
                 </div>
-            @endif
-            <div>
-                <h1 class="classic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+            </td>
+            <td>
+                <div class="classic-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                 @if ($headline)
-                    <p class="classic-headline">{{ strtoupper($headline) }}</p>
+                    <div class="classic-headline">{{ strtoupper($headline) }}</div>
                 @endif
-            </div>
-        </div>
-    </header>
-    <div class="classic-layout">
-        <main>
-            @if ($summary)
-                <section class="classic-summary">{{ $summary }}</section>
-            @endif
-
-            @if (!empty($experienceItems))
-                <section class="classic-section">
-                    <h2 class="classic-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="classic-item">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="classic-meta">
-                                {{ $experience['company'] }}
-                                @if ($experience['company'] && $experience['location'])
-                                    &middot;
-                                @endif
-                                {{ $experience['location'] }}
-                            </p>
-                            <p class="classic-meta">
-                                {{ $experience['from'] ?: 'Unknown' }}
-                                &ndash;
-                                {{ $experience['to'] ?: 'Unknown' }}
-                            </p>
-                            @if ($experience['achievements'])
-                                <p>{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-
-            @if (!empty($educationItems))
-                <section class="classic-section" style="margin-top: 24px;">
-                    <h2 class="classic-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="classic-item">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="classic-meta">
-                                {{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}
-                            </p>
-                            <p class="classic-meta">
-                                {{ $education['location'] }}
-                                @if ($education['location'] && ($education['start'] || $education['end']))
-                                    &middot;
-                                @endif
-                                {{ collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ') }}
-                            </p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
+            </td>
             @if (!empty($contactItems))
-                <section style="margin-bottom: 20px;">
-                    <h2 class="classic-section-title">Contact</h2>
-                    <div class="classic-contact">
+                <td style="width: 220px;">
+                    <ul class="classic-contact">
                         @foreach ($contactItems as $contact)
-                            <span>{{ $contact }}</span>
+                            <li>{{ $contact }}</li>
                         @endforeach
-                    </div>
-                </section>
+                    </ul>
+                </td>
             @endif
+        </tr>
+    </table>
 
-            @if (!empty($skills))
-                <section style="margin-bottom: 20px;">
-                    <h2 class="classic-section-title">Skills</h2>
-                    <div class="classic-taglist">
-                        @foreach ($skills as $skill)
-                            <span class="classic-tag">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+    @if ($summaryParagraphs->isNotEmpty())
+        <div class="classic-summary">
+            @foreach ($summaryParagraphs as $paragraph)
+                <p>{{ $paragraph }}</p>
+            @endforeach
+        </div>
+    @endif
 
-            @if (!empty($languages))
-                <section style="margin-bottom: 20px;">
-                    <h2 class="classic-section-title">Languages</h2>
-                    <ul class="classic-contact">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span> &middot; {{ $language['level'] }}</span>
+    <table class="classic-columns">
+        <tr>
+            <td class="classic-main" @if (! $hasClassicAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                @if ($experienceBlocks->isNotEmpty())
+                    <div class="classic-section">
+                        <div class="classic-section-title">{{ __('Experience') }}</div>
+                        @foreach ($experienceBlocks as $experience)
+                            <div class="classic-entry">
+                                @if (!empty($experience['position']))
+                                    <div class="classic-entry-title">{{ $experience['position'] }}</div>
                                 @endif
-                            </li>
+                                @php
+                                    $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                    $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                @endphp
+                                @if ($metaPieces->isNotEmpty())
+                                    <div class="classic-entry-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($timePieces->isNotEmpty())
+                                    <div class="classic-entry-meta">{{ $timePieces->implode(' – ') }}</div>
+                                @endif
+                                @if ($experience['bullets']->isNotEmpty())
+                                    <ul class="classic-bullets">
+                                        @foreach ($experience['bullets'] as $bullet)
+                                            <li>{{ $bullet }}</li>
+                                        @endforeach
+                                    </ul>
+                                @elseif (!empty($experience['achievements']))
+                                    <p class="classic-entry-meta" style="color: #42392f; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                @endif
+                            </div>
                         @endforeach
-                    </ul>
-                </section>
-            @endif
+                    </div>
+                @endif
 
-            @if (!empty($hobbies))
-                <section>
-                    <h2 class="classic-section-title">Interests</h2>
-                    <ul class="classic-contact">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
+                @if ($educationBlocks->isNotEmpty())
+                    <div class="classic-section">
+                        <div class="classic-section-title">{{ __('Education') }}</div>
+                        @foreach ($educationBlocks as $education)
+                            <div class="classic-entry">
+                                @if (!empty($education['institution']))
+                                    <div class="classic-entry-title">{{ $education['institution'] }}</div>
+                                @endif
+                                @php
+                                    $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                    $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                    $locationPieces = collect([$education['location'] ?? null])->filter();
+                                @endphp
+                                @if ($studyPieces->isNotEmpty())
+                                    <div class="classic-entry-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                    <div class="classic-entry-meta">
+                                        {{ $locationPieces->implode(' · ') }}
+                                        @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                            ·
+                                        @endif
+                                        {{ $durationPieces->implode(' – ') }}
+                                    </div>
+                                @endif
+                            </div>
                         @endforeach
-                    </ul>
-                </section>
+                    </div>
+                @endif
+            </td>
+            @if ($hasClassicAside)
+                <td class="classic-aside">
+                    @if ($skillTags->isNotEmpty())
+                        <div class="classic-section">
+                            <div class="classic-section-title">{{ __('Skills') }}</div>
+                            <ul class="classic-chip-list">
+                                @foreach ($skillTags as $skill)
+                                    <li>{{ $skill }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($languageItems->isNotEmpty())
+                        <div class="classic-section">
+                            <div class="classic-section-title">{{ __('Languages') }}</div>
+                            <ul class="classic-simple-list">
+                                @foreach ($languageItems as $language)
+                                    <li>
+                                        {{ $language['name'] }}
+                                        @if ($language['level'])
+                                            <span>· {{ $language['level'] }}</span>
+                                        @endif
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($hobbyItems->isNotEmpty())
+                        <div class="classic-section">
+                            <div class="classic-section-title">{{ __('Interests') }}</div>
+                            <ul class="classic-simple-list">
+                                @foreach ($hobbyItems as $hobby)
+                                    <li>{{ $hobby }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                </td>
             @endif
-        </aside>
-    </div>
+        </tr>
+    </table>
 </div>

--- a/resources/views/cv/pdf/templates/corporate.blade.php
+++ b/resources/views/cv/pdf/templates/corporate.blade.php
@@ -1,195 +1,373 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#0f172a';
+    $hasCorporateAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-corporate {
-        background: #f1f5f9;
+    body.template-corporate {
+        background-color: #eef1f6;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
         color: #0f172a;
     }
-    .template-corporate .corporate-wrapper {
-        width: 100%;
-        background: #ffffff;
+
+    body.template-corporate .corporate-page {
+        background-color: #ffffff;
+        border: 1px solid #cbd5e1;
         border-radius: 20px;
-        border: 1px solid rgba(15, 23, 42, 0.1);
         overflow: hidden;
-        display: grid;
-        grid-template-columns: 1fr 2fr;
     }
-    .template-corporate .corporate-sidebar {
-        background: #0f172a;
-        color: #e2e8f0;
-        padding: 32px 24px;
-        display: grid;
-        gap: 24px;
+
+    body.template-corporate .corporate-header {
+        background-color: {{ $accent }};
+        color: #ffffff;
+        padding: 24px 30px;
     }
-    .template-corporate .corporate-avatar {
-        width: 86px;
-        height: 86px;
-        border-radius: 999px;
-        border: 3px solid rgba(148, 163, 184, 0.4);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: rgba(15, 23, 42, 0.6);
-        color: #f8fafc;
-        margin-bottom: 18px;
-    }
-    .template-corporate .corporate-avatar img {
+
+    body.template-corporate .corporate-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-corporate .corporate-header td {
+        vertical-align: top;
+    }
+
+    body.template-corporate .corporate-avatar {
+        width: 92px;
+        height: 92px;
+        border-radius: 46px;
+        border: 3px solid rgba(255, 255, 255, 0.45);
+        overflow: hidden;
+        background-color: rgba(15, 23, 42, 0.35);
+    }
+
+    body.template-corporate .corporate-avatar img {
+        width: 92px;
+        height: 92px;
         object-fit: cover;
     }
-    .template-corporate .corporate-avatar-initials {
-        font-size: 20px;
-        font-weight: 600;
-        letter-spacing: 0.2em;
-    }
-    .template-corporate .corporate-name {
+
+    body.template-corporate .corporate-avatar span {
+        display: block;
+        width: 92px;
+        height: 92px;
+        line-height: 92px;
+        text-align: center;
         font-size: 24px;
-        font-weight: 600;
-        letter-spacing: 0.05em;
+        letter-spacing: 5px;
+        color: #ffffff;
     }
-    .template-corporate .corporate-headline {
-        font-size: 11px;
-        letter-spacing: 0.28em;
+
+    body.template-corporate .corporate-name {
+        font-size: 28px;
+        letter-spacing: 3px;
         text-transform: uppercase;
-        color: rgba(148, 163, 184, 0.9);
-        margin-top: 8px;
+        margin: 0;
     }
-    .template-corporate .corporate-contact,
-    .template-corporate .corporate-list {
-        display: grid;
-        gap: 6px;
-        font-size: 11px;
-    }
-    .template-corporate .corporate-body {
-        padding: 32px 34px;
-    }
-    .template-corporate .corporate-section-title {
+
+    body.template-corporate .corporate-headline {
         font-size: 12px;
+        letter-spacing: 4px;
         text-transform: uppercase;
-        letter-spacing: 0.35em;
+        margin-top: 6px;
+        color: rgba(255, 255, 255, 0.75);
+    }
+
+    body.template-corporate .corporate-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        font-size: 11px;
+        color: rgba(255, 255, 255, 0.85);
+    }
+
+    body.template-corporate .corporate-contact li {
+        margin-bottom: 4px;
+    }
+
+    body.template-corporate .corporate-body {
+        padding: 28px 32px 32px;
+    }
+
+    body.template-corporate .corporate-summary {
+        border-left: 4px solid {{ $accent }};
+        background-color: #f8fafc;
+        padding: 16px 20px;
+        margin-bottom: 24px;
+        font-size: 12px;
         color: #1f2937;
-        margin-bottom: 14px;
     }
-    .template-corporate .corporate-item {
-        border-left: 3px solid rgba(15, 23, 42, 0.1);
-        padding-left: 16px;
-        margin-bottom: 20px;
+
+    body.template-corporate .corporate-summary p {
+        margin: 0 0 10px 0;
     }
-    .template-corporate .corporate-item:last-child {
+
+    body.template-corporate .corporate-summary p:last-child {
         margin-bottom: 0;
     }
-    .template-corporate .corporate-item h3 {
-        font-size: 13px;
-        font-weight: 600;
-        margin-bottom: 6px;
+
+    body.template-corporate .corporate-columns {
+        width: 100%;
+        border-collapse: collapse;
     }
-    .template-corporate .corporate-meta {
+
+    body.template-corporate .corporate-columns td {
+        vertical-align: top;
+    }
+
+    body.template-corporate .corporate-main {
+        width: 65%;
+        padding-right: 20px;
+        border-right: 1px solid #e2e8f0;
+    }
+
+    body.template-corporate .corporate-aside {
+        width: 35%;
+        padding-left: 20px;
+    }
+
+    body.template-corporate .corporate-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-corporate .corporate-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-corporate .corporate-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: {{ $accent }};
+        margin-bottom: 10px;
+    }
+
+    body.template-corporate .corporate-entry {
+        margin-bottom: 18px;
+        padding-left: 12px;
+        border-left: 3px solid rgba(15, 23, 42, 0.2);
+    }
+
+    body.template-corporate .corporate-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-corporate .corporate-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #0f172a;
+    }
+
+    body.template-corporate .corporate-meta {
         font-size: 11px;
         color: #475569;
+        margin-top: 4px;
     }
-    .template-corporate .corporate-summary {
+
+    body.template-corporate .corporate-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-corporate .corporate-bullets li {
         font-size: 12px;
-        margin-bottom: 24px;
         color: #1f2937;
+        margin-bottom: 6px;
+    }
+
+    body.template-corporate .corporate-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-corporate .corporate-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-corporate .corporate-chip-list li {
+        display: inline-block;
+        background-color: #f1f5f9;
+        border: 1px solid #d1d9e6;
+        border-radius: 999px;
+        padding: 4px 11px;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        color: #0f172a;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-corporate .corporate-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-corporate .corporate-simple-list li {
+        font-size: 11px;
+        color: #1f2937;
+        margin-bottom: 6px;
+    }
+
+    body.template-corporate .corporate-simple-list li span {
+        color: #64748b;
     }
 </style>
-<div class="corporate-wrapper">
-    <aside class="corporate-sidebar">
-        <div>
-            @if ($profileImage)
-                <div class="corporate-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <h1 class="corporate-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="corporate-headline">{{ strtoupper($headline) }}</p>
-            @endif
-        </div>
-        @if ($summary)
-            <div>
-                <div style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3em; color: rgba(148, 163, 184, 0.9);">Summary</div>
-                <p style="font-size: 11px; line-height: 1.6;">{{ $summary }}</p>
-            </div>
-        @endif
-        @if (!empty($contactItems))
-            <div>
-                <div style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3em; color: rgba(148, 163, 184, 0.9);">Contact</div>
-                <div class="corporate-contact">
-                    @foreach ($contactItems as $contact)
-                        <span>{{ $contact }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($skills))
-            <div>
-                <div style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3em; color: rgba(148, 163, 184, 0.9);">Skills</div>
-                <div class="corporate-list">
-                    @foreach ($skills as $skill)
-                        <span>{{ $skill }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($languages))
-            <div>
-                <div style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3em; color: rgba(148, 163, 184, 0.9);">Languages</div>
-                <div class="corporate-list">
-                    @foreach ($languages as $language)
-                        <span>
-                            {{ $language['name'] }}
-                            @if ($language['level'])
-                                <span>&middot; {{ $language['level'] }}</span>
-                            @endif
-                        </span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($hobbies))
-            <div>
-                <div style="font-size: 10px; text-transform: uppercase; letter-spacing: 0.3em; color: rgba(148, 163, 184, 0.9);">Interests</div>
-                <div class="corporate-list">
-                    @foreach ($hobbies as $hobby)
-                        <span>{{ $hobby }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-    </aside>
-    <main class="corporate-body">
-        @if (!empty($experienceItems))
-            <section style="margin-bottom: 32px;">
-                <h2 class="corporate-section-title">Experience</h2>
-                @foreach ($experienceItems as $experience)
-                    <article class="corporate-item">
-                        @if ($experience['position'])
-                            <h3>{{ $experience['position'] }}</h3>
+
+<div class="corporate-page">
+    <header class="corporate-header">
+        <table>
+            <tr>
+                <td style="width: 120px;">
+                    <div class="corporate-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
                         @endif
-                        <p class="corporate-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                        <p class="corporate-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                        @if ($experience['achievements'])
-                            <p style="margin-top: 8px; font-size: 11px;">{{ $experience['achievements'] }}</p>
-                        @endif
-                    </article>
+                    </div>
+                </td>
+                <td>
+                    <div class="corporate-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="corporate-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="corporate-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
+                @endif
+            </tr>
+        </table>
+    </header>
+
+    <div class="corporate-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="corporate-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
-            </section>
+            </div>
         @endif
 
-        @if (!empty($educationItems))
-            <section>
-                <h2 class="corporate-section-title">Education</h2>
-                @foreach ($educationItems as $education)
-                    <article class="corporate-item">
-                        @if ($education['institution'])
-                            <h3>{{ $education['institution'] }}</h3>
+        <table class="corporate-columns">
+            <tr>
+                <td class="corporate-main" @if (! $hasCorporateAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="corporate-section">
+                            <div class="corporate-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="corporate-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="corporate-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="corporate-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="corporate-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="corporate-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="corporate-meta" style="color: #1f2937; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="corporate-section">
+                            <div class="corporate-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="corporate-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="corporate-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="corporate-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="corporate-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasCorporateAside)
+                    <td class="corporate-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="corporate-section">
+                                <div class="corporate-title">{{ __('Skills') }}</div>
+                                <ul class="corporate-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
                         @endif
-                        <p class="corporate-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                        <p class="corporate-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                    </article>
-                @endforeach
-            </section>
-        @endif
-    </main>
+
+                        @if ($languageItems->isNotEmpty())
+                            <div class="corporate-section">
+                                <div class="corporate-title">{{ __('Languages') }}</div>
+                                <ul class="corporate-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="corporate-section">
+                                <div class="corporate-title">{{ __('Interests') }}</div>
+                                <ul class="corporate-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
+    </div>
 </div>

--- a/resources/views/cv/pdf/templates/creative.blade.php
+++ b/resources/views/cv/pdf/templates/creative.blade.php
@@ -1,254 +1,390 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#ec4899';
+    $secondary = '#3b82f6';
+    $hasCreativeAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-creative {
-        background: linear-gradient(135deg, rgba(236, 72, 153, 0.08), rgba(59, 130, 246, 0.08));
+    body.template-creative {
+        background-color: #fff6fb;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Trebuchet MS', 'Arial', sans-serif;
+        color: #1f1b2e;
     }
-    .template-creative .creative-wrapper {
-        width: 100%;
-        background: #ffffff;
-        border-radius: 28px;
-        border: 1px solid rgba(236, 72, 153, 0.15);
+
+    body.template-creative .creative-page {
+        background-color: #ffffff;
+        border: 2px solid #fbd1e9;
+        border-radius: 24px;
+        padding: 0;
         overflow: hidden;
     }
-    .template-creative .creative-top {
-        display: grid;
-        grid-template-columns: 1.4fr 1fr;
-        gap: 24px;
-        padding: 32px;
-        background: linear-gradient(120deg, rgba(236, 72, 153, 0.85), rgba(14, 165, 233, 0.75));
+
+    body.template-creative .creative-header {
+        background-color: {{ $accent }};
         color: #ffffff;
+        padding: 24px 30px;
     }
-    .template-creative .creative-avatar {
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        align-items: flex-start;
-    }
-    .template-creative .creative-avatar-block {
-        display: flex;
-        align-items: center;
-        gap: 22px;
-    }
-    .template-creative .creative-avatar-figure {
-        width: 88px;
-        height: 88px;
-        border-radius: 28px;
-        background: rgba(15, 23, 42, 0.18);
-        border: 3px solid rgba(255, 255, 255, 0.55);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: #ffffff;
-    }
-    .template-creative .creative-avatar-figure img {
+
+    body.template-creative .creative-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-creative .creative-header td {
+        vertical-align: top;
+    }
+
+    body.template-creative .creative-avatar {
+        width: 94px;
+        height: 94px;
+        border-radius: 20px;
+        border: 3px solid rgba(255, 255, 255, 0.6);
+        background-color: rgba(15, 23, 42, 0.18);
+        overflow: hidden;
+    }
+
+    body.template-creative .creative-avatar img {
+        width: 94px;
+        height: 94px;
         object-fit: cover;
     }
-    .template-creative .creative-avatar-initials {
-        font-size: 22px;
-        font-weight: 600;
-        letter-spacing: 0.3em;
-    }
-    .template-creative .creative-name {
-        font-size: 30px;
-        font-weight: 700;
-        letter-spacing: 0.01em;
-    }
-    .template-creative .creative-headline {
-        font-size: 13px;
-        text-transform: uppercase;
-        letter-spacing: 0.24em;
-        color: rgba(255, 255, 255, 0.78);
-    }
-    .template-creative .creative-contact {
-        display: grid;
-        gap: 6px;
-        font-size: 11px;
-        color: rgba(255, 255, 255, 0.9);
-    }
-    .template-creative .creative-body {
-        padding: 28px 32px 32px;
-        display: grid;
-        grid-template-columns: 1.4fr 1fr;
-        gap: 28px;
-    }
-    .template-creative .creative-section-title {
-        font-size: 13px;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.3em;
-        color: #0f172a;
-        margin-bottom: 12px;
-    }
-    .template-creative .creative-card {
-        border-radius: 20px;
-        padding: 18px 20px;
-        margin-bottom: 18px;
-        background: linear-gradient(135deg, rgba(255, 255, 255, 1), rgba(148, 163, 184, 0.15));
-        border: 1px solid rgba(148, 163, 184, 0.3);
-    }
-    .template-creative .creative-card:last-child {
-        margin-bottom: 0;
-    }
-    .template-creative .creative-card h3 {
-        font-size: 14px;
-        font-weight: 600;
-        color: #0f172a;
-    }
-    .template-creative .creative-meta {
-        font-size: 11px;
-        color: #475569;
-        margin-top: 4px;
-    }
-    .template-creative .creative-pill {
-        display: inline-block;
-        padding: 6px 12px;
-        border-radius: 999px;
-        font-size: 10px;
-        letter-spacing: 0.3em;
-        text-transform: uppercase;
-        background: rgba(255, 255, 255, 0.2);
-        border: 1px solid rgba(255, 255, 255, 0.4);
+
+    body.template-creative .creative-avatar span {
+        display: block;
+        width: 94px;
+        height: 94px;
+        line-height: 94px;
+        text-align: center;
+        font-size: 26px;
+        letter-spacing: 4px;
         color: #ffffff;
     }
-    .template-creative .creative-badge {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 10px;
-        letter-spacing: 0.3em;
+
+    body.template-creative .creative-name {
+        font-size: 30px;
+        letter-spacing: 2px;
         text-transform: uppercase;
-        color: #6366f1;
-        margin-bottom: 12px;
+        margin: 0;
     }
-    .template-creative .creative-aside-card {
-        border-radius: 22px;
-        padding: 18px 20px;
-        background: rgba(248, 250, 252, 0.75);
-        border: 1px dashed rgba(59, 130, 246, 0.35);
-        margin-bottom: 18px;
+
+    body.template-creative .creative-headline {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 4px;
+        margin-top: 6px;
+        color: rgba(255, 255, 255, 0.82);
     }
-    .template-creative .creative-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
+
+    body.template-creative .creative-tagline {
+        display: inline-block;
+        background-color: rgba(255, 255, 255, 0.18);
+        border: 1px solid rgba(255, 255, 255, 0.4);
+        border-radius: 999px;
+        padding: 4px 12px;
+        font-size: 10px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        margin-top: 10px;
     }
-    .template-creative .creative-tag {
-        padding: 6px 12px;
-        border-radius: 14px;
+
+    body.template-creative .creative-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
-        background: rgba(99, 102, 241, 0.12);
-        color: #4338ca;
-        border: 1px solid rgba(99, 102, 241, 0.2);
+    }
+
+    body.template-creative .creative-contact li {
+        margin-bottom: 4px;
+    }
+
+    body.template-creative .creative-body {
+        padding: 26px 32px 32px;
+    }
+
+    body.template-creative .creative-summary {
+        border: 2px dashed rgba(236, 72, 153, 0.35);
+        background-color: #fff0f8;
+        border-radius: 18px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
+        font-size: 12px;
+        color: #312652;
+    }
+
+    body.template-creative .creative-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-creative .creative-summary p:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-creative .creative-columns {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-creative .creative-columns td {
+        vertical-align: top;
+    }
+
+    body.template-creative .creative-main {
+        width: 64%;
+        padding-right: 20px;
+        border-right: 2px dotted #f0d0ff;
+    }
+
+    body.template-creative .creative-aside {
+        width: 36%;
+        padding-left: 20px;
+    }
+
+    body.template-creative .creative-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-creative .creative-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-creative .creative-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: {{ $secondary }};
+        margin-bottom: 10px;
+    }
+
+    body.template-creative .creative-entry {
+        background-color: #fbf6ff;
+        border: 1px solid #e6d9ff;
+        border-radius: 16px;
+        padding: 14px 16px;
+        margin-bottom: 16px;
+    }
+
+    body.template-creative .creative-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-creative .creative-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #1f1b2e;
+    }
+
+    body.template-creative .creative-meta {
+        font-size: 11px;
+        color: #5c4f7f;
+        margin-top: 4px;
+    }
+
+    body.template-creative .creative-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-creative .creative-bullets li {
+        font-size: 12px;
+        color: #312652;
+        margin-bottom: 6px;
+    }
+
+    body.template-creative .creative-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-creative .creative-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-creative .creative-chip-list li {
+        display: inline-block;
+        background-color: rgba(59, 130, 246, 0.12);
+        border: 1px solid rgba(59, 130, 246, 0.35);
+        color: #2563eb;
+        border-radius: 14px;
+        padding: 5px 12px;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-creative .creative-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-creative .creative-simple-list li {
+        font-size: 11px;
+        color: #312652;
+        margin-bottom: 6px;
+    }
+
+    body.template-creative .creative-simple-list li span {
+        color: #6d5bb5;
     }
 </style>
-<div class="creative-wrapper">
-    <div class="creative-top">
-        <div class="creative-avatar">
-            <span class="creative-pill">{{ strtoupper($templateKey ?? 'Creative') }}</span>
-            <div class="creative-avatar-block">
-                @if ($profileImage)
-                    <div class="creative-avatar-figure">
-                        <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+
+<div class="creative-page">
+    <header class="creative-header">
+        <table>
+            <tr>
+                <td style="width: 110px;">
+                    <div class="creative-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
                     </div>
-                @endif
-                <div>
-                    <h1 class="creative-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
+                </td>
+                <td>
+                    <div class="creative-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)
-                        <p class="creative-headline">{{ strtoupper($headline) }}</p>
+                        <div class="creative-headline">{{ strtoupper($headline) }}</div>
                     @endif
-                </div>
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="creative-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
+                    <div class="creative-tagline">{{ strtoupper($templateKey ?? 'Creative') }}</div>
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="creative-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
+                @endif
+            </tr>
+        </table>
+    </header>
+
+    <div class="creative-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="creative-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
             </div>
         @endif
-    </div>
-    <div class="creative-body">
-        <main>
-            @if ($summary)
-                <section class="creative-card" style="margin-bottom: 24px;">
-                    <div class="creative-badge">Spotlight</div>
-                    <p style="color: #1f2937; font-size: 12px;">{{ $summary }}</p>
-                </section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section style="margin-bottom: 26px;">
-                    <h2 class="creative-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="creative-card">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="creative-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                            <p class="creative-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="margin-top: 12px; color: #1e293b;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+        <table class="creative-columns">
+            <tr>
+                <td class="creative-main" @if (! $hasCreativeAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="creative-section">
+                            <div class="creative-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="creative-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="creative-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="creative-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="creative-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="creative-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="creative-meta" style="color: #312652; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
 
-            @if (!empty($educationItems))
-                <section>
-                    <h2 class="creative-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="creative-card">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="creative-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                            <p class="creative-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section class="creative-aside-card">
-                    <h2 class="creative-section-title" style="margin-bottom: 14px;">Skills</h2>
-                    <div class="creative-tags">
-                        @foreach ($skills as $skill)
-                            <span class="creative-tag">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="creative-section">
+                            <div class="creative-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="creative-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="creative-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="creative-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="creative-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasCreativeAside)
+                    <td class="creative-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="creative-section">
+                                <div class="creative-title">{{ __('Skills') }}</div>
+                                <ul class="creative-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($languages))
-                <section class="creative-aside-card">
-                    <h2 class="creative-section-title" style="margin-bottom: 12px;">Languages</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #1f2937;">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #6366f1;"> &middot; {{ $language['level'] }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                        @if ($languageItems->isNotEmpty())
+                            <div class="creative-section">
+                                <div class="creative-title">{{ __('Languages') }}</div>
+                                <ul class="creative-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($hobbies))
-                <section class="creative-aside-card">
-                    <h2 class="creative-section-title" style="margin-bottom: 12px;">Interests</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #1f2937;">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="creative-section">
+                                <div class="creative-title">{{ __('Interests') }}</div>
+                                <ul class="creative-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 </div>

--- a/resources/views/cv/pdf/templates/darkmode.blade.php
+++ b/resources/views/cv/pdf/templates/darkmode.blade.php
@@ -1,224 +1,376 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#1f2937';
+    $highlight = '#22d3ee';
+    $hasDarkAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-darkmode {
-        background: #0b1120;
+    body.template-darkmode {
+        background-color: #0f172a;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
         color: #e2e8f0;
     }
-    .template-darkmode .dark-wrapper {
-        width: 100%;
-        background: #111827;
-        border-radius: 24px;
-        border: 1px solid rgba(148, 163, 184, 0.25);
-        padding: 32px;
-        color: #e2e8f0;
-    }
-    .template-darkmode .dark-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        margin-bottom: 28px;
-    }
-    .template-darkmode .dark-header-main {
-        display: flex;
-        align-items: center;
-        gap: 24px;
-    }
-    .template-darkmode .dark-avatar {
-        width: 86px;
-        height: 86px;
-        border-radius: 999px;
-        border: 3px solid rgba(56, 189, 248, 0.6);
+
+    body.template-darkmode .dark-page {
+        background-color: #1f2937;
+        border: 1px solid #374151;
+        border-radius: 20px;
         overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: rgba(15, 118, 110, 0.35);
-        color: #e2e8f0;
     }
-    .template-darkmode .dark-avatar img {
+
+    body.template-darkmode .dark-header {
+        background-color: #111827;
+        padding: 24px 30px;
+        border-bottom: 3px solid {{ $highlight }};
+    }
+
+    body.template-darkmode .dark-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-darkmode .dark-header td {
+        vertical-align: top;
+    }
+
+    body.template-darkmode .dark-avatar {
+        width: 92px;
+        height: 92px;
+        border-radius: 46px;
+        border: 2px solid {{ $highlight }};
+        overflow: hidden;
+        background-color: #0f172a;
+    }
+
+    body.template-darkmode .dark-avatar img {
+        width: 92px;
+        height: 92px;
         object-fit: cover;
     }
-    .template-darkmode .dark-avatar-initials {
-        font-size: 22px;
-        font-weight: 600;
-        letter-spacing: 0.3em;
+
+    body.template-darkmode .dark-avatar span {
+        display: block;
+        width: 92px;
+        height: 92px;
+        line-height: 92px;
+        text-align: center;
+        font-size: 24px;
+        letter-spacing: 4px;
+        color: {{ $highlight }};
     }
-    .template-darkmode .dark-name {
+
+    body.template-darkmode .dark-name {
         font-size: 28px;
-        font-weight: 600;
-        color: #f8fafc;
-    }
-    .template-darkmode .dark-headline {
-        margin-top: 6px;
-        font-size: 11px;
-        letter-spacing: 0.34em;
+        letter-spacing: 3px;
         text-transform: uppercase;
-        color: #38bdf8;
+        margin: 0;
+        color: #f9fafb;
     }
-    .template-darkmode .dark-contact {
-        text-align: right;
-        display: grid;
-        gap: 6px;
-        font-size: 11px;
+
+    body.template-darkmode .dark-headline {
+        font-size: 12px;
+        letter-spacing: 4px;
+        text-transform: uppercase;
+        margin-top: 6px;
         color: #94a3b8;
     }
-    .template-darkmode .dark-grid {
-        display: grid;
-        grid-template-columns: 1.5fr 1fr;
-        gap: 32px;
-    }
-    .template-darkmode .dark-section-title {
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.4em;
-        color: #38bdf8;
-        margin-bottom: 14px;
-    }
-    .template-darkmode .dark-card {
-        border-radius: 18px;
-        border: 1px solid rgba(148, 163, 184, 0.2);
-        background: rgba(15, 23, 42, 0.8);
-        padding: 18px 20px;
-        margin-bottom: 16px;
-    }
-    .template-darkmode .dark-card:last-child {
-        margin-bottom: 0;
-    }
-    .template-darkmode .dark-card h3 {
-        font-size: 13px;
-        color: #f1f5f9;
-    }
-    .template-darkmode .dark-meta {
+
+    body.template-darkmode .dark-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
         color: #cbd5f5;
+    }
+
+    body.template-darkmode .dark-contact li {
+        margin-bottom: 4px;
+    }
+
+    body.template-darkmode .dark-body {
+        padding: 26px 30px 30px;
+    }
+
+    body.template-darkmode .dark-summary {
+        border: 1px solid #374151;
+        background-color: #0f172a;
+        border-radius: 16px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
+        font-size: 12px;
+        color: #cbd5f5;
+    }
+
+    body.template-darkmode .dark-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-darkmode .dark-summary p:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-darkmode .dark-columns {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-darkmode .dark-columns td {
+        vertical-align: top;
+    }
+
+    body.template-darkmode .dark-main {
+        width: 65%;
+        padding-right: 20px;
+        border-right: 1px solid #374151;
+    }
+
+    body.template-darkmode .dark-aside {
+        width: 35%;
+        padding-left: 20px;
+    }
+
+    body.template-darkmode .dark-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-darkmode .dark-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-darkmode .dark-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: {{ $highlight }};
+        margin-bottom: 10px;
+    }
+
+    body.template-darkmode .dark-entry {
+        margin-bottom: 18px;
+        padding-left: 12px;
+        border-left: 3px solid rgba(34, 211, 238, 0.35);
+    }
+
+    body.template-darkmode .dark-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-darkmode .dark-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #e2e8f0;
+    }
+
+    body.template-darkmode .dark-meta {
+        font-size: 11px;
+        color: #94a3b8;
         margin-top: 4px;
     }
-    .template-darkmode .dark-summary {
-        background: rgba(8, 145, 178, 0.12);
-        border: 1px solid rgba(56, 189, 248, 0.25);
-        padding: 18px;
-        border-radius: 18px;
+
+    body.template-darkmode .dark-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-darkmode .dark-bullets li {
         font-size: 12px;
-        color: #e0f2fe;
-        margin-bottom: 24px;
+        color: #cbd5f5;
+        margin-bottom: 6px;
     }
-    .template-darkmode .dark-chiplist {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
+
+    body.template-darkmode .dark-bullets li:last-child {
+        margin-bottom: 0;
     }
-    .template-darkmode .dark-chip {
-        padding: 6px 12px;
+
+    body.template-darkmode .dark-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-darkmode .dark-chip-list li {
+        display: inline-block;
+        background-color: rgba(34, 211, 238, 0.12);
+        border: 1px solid rgba(34, 211, 238, 0.35);
         border-radius: 999px;
+        padding: 4px 11px;
         font-size: 10px;
-        letter-spacing: 0.3em;
+        letter-spacing: 2px;
         text-transform: uppercase;
-        background: rgba(56, 189, 248, 0.1);
-        color: #38bdf8;
-        border: 1px solid rgba(56, 189, 248, 0.3);
+        color: #67e8f9;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-darkmode .dark-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-darkmode .dark-simple-list li {
+        font-size: 11px;
+        color: #cbd5f5;
+        margin-bottom: 6px;
+    }
+
+    body.template-darkmode .dark-simple-list li span {
+        color: #67e8f9;
     }
 </style>
-<div class="dark-wrapper">
+
+<div class="dark-page">
     <header class="dark-header">
-        <div class="dark-header-main">
-            @if ($profileImage)
-                <div class="dark-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div>
-                <h1 class="dark-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-                @if ($headline)
-                    <p class="dark-headline">{{ strtoupper($headline) }}</p>
+        <table>
+            <tr>
+                <td style="width: 120px;">
+                    <div class="dark-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
+                    </div>
+                </td>
+                <td>
+                    <div class="dark-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="dark-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="dark-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
                 @endif
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="dark-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
+            </tr>
+        </table>
+    </header>
+
+    <div class="dark-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="dark-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
             </div>
         @endif
-    </header>
-    <div class="dark-grid">
-        <main>
-            @if ($summary)
-                <section class="dark-summary">{{ $summary }}</section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section style="margin-bottom: 24px;">
-                    <h2 class="dark-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="dark-card">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="dark-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                            <p class="dark-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="margin-top: 10px; color: #bae6fd;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+        <table class="dark-columns">
+            <tr>
+                <td class="dark-main" @if (! $hasDarkAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="dark-section">
+                            <div class="dark-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="dark-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="dark-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="dark-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="dark-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="dark-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="dark-meta" style="color: #cbd5f5; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
 
-            @if (!empty($educationItems))
-                <section>
-                    <h2 class="dark-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="dark-card">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="dark-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                            <p class="dark-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section style="margin-bottom: 20px;">
-                    <h2 class="dark-section-title">Skills</h2>
-                    <div class="dark-chiplist">
-                        @foreach ($skills as $skill)
-                            <span class="dark-chip">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="dark-section">
+                            <div class="dark-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="dark-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="dark-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="dark-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="dark-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasDarkAside)
+                    <td class="dark-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="dark-section">
+                                <div class="dark-title">{{ __('Skills') }}</div>
+                                <ul class="dark-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($languages))
-                <section style="margin-bottom: 20px;">
-                    <h2 class="dark-section-title">Languages</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #e2e8f0;">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #38bdf8;"> &middot; {{ $language['level'] }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                        @if ($languageItems->isNotEmpty())
+                            <div class="dark-section">
+                                <div class="dark-title">{{ __('Languages') }}</div>
+                                <ul class="dark-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($hobbies))
-                <section>
-                    <h2 class="dark-section-title">Interests</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #e2e8f0;">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="dark-section">
+                                <div class="dark-title">{{ __('Interests') }}</div>
+                                <ul class="dark-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 </div>

--- a/resources/views/cv/pdf/templates/elegant.blade.php
+++ b/resources/views/cv/pdf/templates/elegant.blade.php
@@ -1,208 +1,367 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#c026d3';
+    $hasElegantAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-elegant {
-        background: #fcf7ff;
-        font-family: 'Georgia', 'Times New Roman', serif;
-        color: #2d1b4e;
+    body.template-elegant {
+        background-color: #f7f5ff;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Georgia', 'Times New Roman', serif;
+        color: #2c1b33;
     }
-    .template-elegant .elegant-wrapper {
+
+    body.template-elegant .elegant-page {
+        background-color: #ffffff;
+        border: 1px solid #dccdf2;
+        border-radius: 24px;
+        padding: 30px 34px;
+    }
+
+    body.template-elegant .elegant-header {
+        border-bottom: 2px solid {{ $accent }};
+        padding-bottom: 20px;
+        margin-bottom: 24px;
+    }
+
+    body.template-elegant .elegant-header table {
         width: 100%;
-        background: #ffffff;
-        border-radius: 26px;
-        border: 1px solid rgba(192, 38, 211, 0.2);
+        border-collapse: collapse;
+    }
+
+    body.template-elegant .elegant-header td {
+        vertical-align: top;
+    }
+
+    body.template-elegant .elegant-avatar {
+        width: 100px;
+        height: 100px;
+        border-radius: 50px;
+        border: 4px double {{ $accent }};
         overflow: hidden;
-        display: grid;
-        grid-template-columns: 0.8fr 2fr;
+        background-color: #f4ecff;
     }
-    .template-elegant .elegant-sidebar {
-        background: linear-gradient(180deg, rgba(192, 38, 211, 0.85), rgba(79, 70, 229, 0.85));
-        color: #fdf4ff;
-        padding: 34px 24px;
-        display: grid;
-        gap: 24px;
-    }
-    .template-elegant .elegant-portrait {
-        width: 92px;
-        height: 92px;
-        border-radius: 30px;
-        background: rgba(255, 255, 255, 0.15);
-        border: 3px solid rgba(255, 255, 255, 0.45);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        margin-bottom: 18px;
-        color: #fdf4ff;
-    }
-    .template-elegant .elegant-portrait img {
-        width: 100%;
-        height: 100%;
+
+    body.template-elegant .elegant-avatar img {
+        width: 100px;
+        height: 100px;
         object-fit: cover;
     }
-    .template-elegant .elegant-portrait-initials {
-        font-size: 22px;
-        letter-spacing: 0.4em;
-    }
-    .template-elegant .elegant-name {
+
+    body.template-elegant .elegant-avatar span {
+        display: block;
+        width: 100px;
+        height: 100px;
+        line-height: 100px;
+        text-align: center;
         font-size: 26px;
-        letter-spacing: 0.08em;
+        letter-spacing: 5px;
+        color: {{ $accent }};
     }
-    .template-elegant .elegant-headline {
+
+    body.template-elegant .elegant-name {
+        font-size: 30px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        margin: 0;
+    }
+
+    body.template-elegant .elegant-headline {
+        font-size: 12px;
+        letter-spacing: 5px;
+        text-transform: uppercase;
         margin-top: 6px;
-        font-size: 12px;
-        letter-spacing: 0.4em;
-        text-transform: uppercase;
-        color: rgba(255, 255, 255, 0.78);
+        color: #7c4ba0;
     }
-    .template-elegant .elegant-contact {
-        display: grid;
-        gap: 6px;
+
+    body.template-elegant .elegant-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
-        color: rgba(255, 255, 255, 0.9);
+        color: #5a3e6b;
+        text-align: right;
     }
-    .template-elegant .elegant-badge {
-        font-size: 10px;
-        letter-spacing: 0.4em;
-        text-transform: uppercase;
-        color: rgba(255, 255, 255, 0.7);
+
+    body.template-elegant .elegant-contact li {
+        margin-bottom: 4px;
     }
-    .template-elegant .elegant-body {
-        padding: 34px 36px;
-    }
-    .template-elegant .elegant-section-title {
+
+    body.template-elegant .elegant-summary {
+        background-color: #f9f3ff;
+        border: 1px solid #e8d9fb;
+        border-radius: 18px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
         font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.32em;
-        color: #7c3aed;
-        margin-bottom: 14px;
+        color: #3c2a47;
     }
-    .template-elegant .elegant-divider {
-        height: 1px;
-        background: rgba(124, 58, 237, 0.25);
-        margin-bottom: 16px;
+
+    body.template-elegant .elegant-summary p {
+        margin: 0 0 10px 0;
     }
-    .template-elegant .elegant-item {
-        margin-bottom: 20px;
+
+    body.template-elegant .elegant-summary p:last-child {
+        margin-bottom: 0;
     }
-    .template-elegant .elegant-item h3 {
-        font-size: 14px;
-        letter-spacing: 0.04em;
-        margin-bottom: 6px;
+
+    body.template-elegant .elegant-columns {
+        width: 100%;
+        border-collapse: collapse;
     }
-    .template-elegant .elegant-meta {
-        font-size: 11px;
-        color: #5b21b6;
+
+    body.template-elegant .elegant-columns td {
+        vertical-align: top;
     }
-    .template-elegant .elegant-summary {
-        font-size: 12px;
-        line-height: 1.6;
+
+    body.template-elegant .elegant-main {
+        width: 64%;
+        padding-right: 22px;
+        border-right: 1px solid #e3d8f6;
+    }
+
+    body.template-elegant .elegant-aside {
+        width: 36%;
+        padding-left: 22px;
+    }
+
+    body.template-elegant .elegant-section {
         margin-bottom: 26px;
     }
-    .template-elegant .elegant-list {
-        display: grid;
-        gap: 6px;
+
+    body.template-elegant .elegant-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-elegant .elegant-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 4px;
+        color: {{ $accent }};
+        margin-bottom: 10px;
+    }
+
+    body.template-elegant .elegant-entry {
+        margin-bottom: 18px;
+    }
+
+    body.template-elegant .elegant-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-elegant .elegant-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #2c1b33;
+    }
+
+    body.template-elegant .elegant-meta {
         font-size: 11px;
+        color: #6a4a7d;
+        margin-top: 4px;
+    }
+
+    body.template-elegant .elegant-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-elegant .elegant-bullets li {
+        font-size: 12px;
+        color: #3c2a47;
+        margin-bottom: 6px;
+    }
+
+    body.template-elegant .elegant-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-elegant .elegant-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-elegant .elegant-chip-list li {
+        display: inline-block;
+        background-color: #f3e9ff;
+        border: 1px solid #e2d0fb;
+        border-radius: 18px;
+        padding: 5px 12px;
+        font-size: 10px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        color: #7c4ba0;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-elegant .elegant-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-elegant .elegant-simple-list li {
+        font-size: 11px;
+        color: #3c2a47;
+        margin-bottom: 6px;
+    }
+
+    body.template-elegant .elegant-simple-list li span {
+        color: #7c4ba0;
     }
 </style>
-<div class="elegant-wrapper">
-    <aside class="elegant-sidebar">
-        <div>
-            @if ($profileImage)
-                <div class="elegant-portrait">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div class="elegant-badge">Profile</div>
-            <h1 class="elegant-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-            @if ($headline)
-                <p class="elegant-headline">{{ strtoupper($headline) }}</p>
-            @endif
-        </div>
-        @if ($summary)
-            <div>
-                <div class="elegant-badge">About</div>
-                <p style="font-size: 11px; line-height: 1.6;">{{ $summary }}</p>
-            </div>
-        @endif
-        @if (!empty($contactItems))
-            <div>
-                <div class="elegant-badge">Contact</div>
-                <div class="elegant-contact">
-                    @foreach ($contactItems as $contact)
-                        <span>{{ $contact }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($skills))
-            <div>
-                <div class="elegant-badge">Skills</div>
-                <div class="elegant-contact">
-                    @foreach ($skills as $skill)
-                        <span>{{ $skill }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($languages))
-            <div>
-                <div class="elegant-badge">Languages</div>
-                <div class="elegant-contact">
-                    @foreach ($languages as $language)
-                        <span>
-                            {{ $language['name'] }}
-                            @if ($language['level'])
-                                <span>&middot; {{ $language['level'] }}</span>
-                            @endif
-                        </span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-        @if (!empty($hobbies))
-            <div>
-                <div class="elegant-badge">Interests</div>
-                <div class="elegant-contact">
-                    @foreach ($hobbies as $hobby)
-                        <span>{{ $hobby }}</span>
-                    @endforeach
-                </div>
-            </div>
-        @endif
-    </aside>
-    <main class="elegant-body">
-        @if (!empty($experienceItems))
-            <section style="margin-bottom: 32px;">
-                <h2 class="elegant-section-title">Experience</h2>
-                <div class="elegant-divider"></div>
-                @foreach ($experienceItems as $experience)
-                    <article class="elegant-item">
-                        @if ($experience['position'])
-                            <h3>{{ $experience['position'] }}</h3>
-                        @endif
-                        <p class="elegant-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                        <p class="elegant-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                        @if ($experience['achievements'])
-                            <p style="margin-top: 10px; font-size: 12px;">{{ $experience['achievements'] }}</p>
-                        @endif
-                    </article>
-                @endforeach
-            </section>
-        @endif
 
-        @if (!empty($educationItems))
-            <section>
-                <h2 class="elegant-section-title">Education</h2>
-                <div class="elegant-divider"></div>
-                @foreach ($educationItems as $education)
-                    <article class="elegant-item">
-                        @if ($education['institution'])
-                            <h3>{{ $education['institution'] }}</h3>
+<div class="elegant-page">
+    <header class="elegant-header">
+        <table>
+            <tr>
+                <td style="width: 120px;">
+                    <div class="elegant-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
                         @endif
-                        <p class="elegant-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                        <p class="elegant-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                    </article>
-                @endforeach
-            </section>
-        @endif
-    </main>
+                    </div>
+                </td>
+                <td>
+                    <div class="elegant-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="elegant-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="elegant-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
+                @endif
+            </tr>
+        </table>
+    </header>
+
+    @if ($summaryParagraphs->isNotEmpty())
+        <div class="elegant-summary">
+            @foreach ($summaryParagraphs as $paragraph)
+                <p>{{ $paragraph }}</p>
+            @endforeach
+        </div>
+    @endif
+
+    <table class="elegant-columns">
+        <tr>
+            <td class="elegant-main" @if (! $hasElegantAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                @if ($experienceBlocks->isNotEmpty())
+                    <div class="elegant-section">
+                        <div class="elegant-title">{{ __('Experience') }}</div>
+                        @foreach ($experienceBlocks as $experience)
+                            <div class="elegant-entry">
+                                @if (!empty($experience['position']))
+                                    <div class="elegant-entry-title">{{ $experience['position'] }}</div>
+                                @endif
+                                @php
+                                    $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                    $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                @endphp
+                                @if ($metaPieces->isNotEmpty())
+                                    <div class="elegant-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($timePieces->isNotEmpty())
+                                    <div class="elegant-meta">{{ $timePieces->implode(' – ') }}</div>
+                                @endif
+                                @if ($experience['bullets']->isNotEmpty())
+                                    <ul class="elegant-bullets">
+                                        @foreach ($experience['bullets'] as $bullet)
+                                            <li>{{ $bullet }}</li>
+                                        @endforeach
+                                    </ul>
+                                @elseif (!empty($experience['achievements']))
+                                    <p class="elegant-meta" style="color: #3c2a47; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+
+                @if ($educationBlocks->isNotEmpty())
+                    <div class="elegant-section">
+                        <div class="elegant-title">{{ __('Education') }}</div>
+                        @foreach ($educationBlocks as $education)
+                            <div class="elegant-entry">
+                                @if (!empty($education['institution']))
+                                    <div class="elegant-entry-title">{{ $education['institution'] }}</div>
+                                @endif
+                                @php
+                                    $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                    $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                    $locationPieces = collect([$education['location'] ?? null])->filter();
+                                @endphp
+                                @if ($studyPieces->isNotEmpty())
+                                    <div class="elegant-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                    <div class="elegant-meta">
+                                        {{ $locationPieces->implode(' · ') }}
+                                        @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                            ·
+                                        @endif
+                                        {{ $durationPieces->implode(' – ') }}
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
+            </td>
+            @if ($hasElegantAside)
+                <td class="elegant-aside">
+                    @if ($skillTags->isNotEmpty())
+                        <div class="elegant-section">
+                            <div class="elegant-title">{{ __('Skills') }}</div>
+                            <ul class="elegant-chip-list">
+                                @foreach ($skillTags as $skill)
+                                    <li>{{ $skill }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($languageItems->isNotEmpty())
+                        <div class="elegant-section">
+                            <div class="elegant-title">{{ __('Languages') }}</div>
+                            <ul class="elegant-simple-list">
+                                @foreach ($languageItems as $language)
+                                    <li>
+                                        {{ $language['name'] }}
+                                        @if ($language['level'])
+                                            <span>· {{ $language['level'] }}</span>
+                                        @endif
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($hobbyItems->isNotEmpty())
+                        <div class="elegant-section">
+                            <div class="elegant-title">{{ __('Interests') }}</div>
+                            <ul class="elegant-simple-list">
+                                @foreach ($hobbyItems as $hobby)
+                                    <li>{{ $hobby }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                </td>
+            @endif
+        </tr>
+    </table>
 </div>

--- a/resources/views/cv/pdf/templates/futuristic.blade.php
+++ b/resources/views/cv/pdf/templates/futuristic.blade.php
@@ -1,234 +1,382 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#7c3aed';
+    $secondary = '#22d3ee';
+    $hasFuturisticAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-futuristic {
-        background: radial-gradient(circle at top left, rgba(124, 58, 237, 0.25), transparent 45%), #0f172a;
-        color: #e2e8f0;
+    body.template-futuristic {
+        background-color: #06080f;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
+        color: #e5edff;
     }
-    .template-futuristic .futuristic-wrapper {
-        width: 100%;
-        background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 41, 59, 0.95));
-        border-radius: 28px;
-        border: 1px solid rgba(124, 58, 237, 0.35);
-        padding: 34px;
-    }
-    .template-futuristic .futuristic-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        margin-bottom: 30px;
-    }
-    .template-futuristic .futuristic-header-main {
-        display: flex;
-        align-items: center;
-        gap: 24px;
-    }
-    .template-futuristic .futuristic-avatar {
-        width: 88px;
-        height: 88px;
-        border-radius: 28px;
-        border: 3px solid rgba(124, 58, 237, 0.6);
+
+    body.template-futuristic .futuristic-page {
+        background-color: #111827;
+        border: 1px solid #1f2937;
+        border-radius: 24px;
         overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: radial-gradient(circle at center, rgba(168, 85, 247, 0.3), rgba(30, 64, 175, 0.35));
-        color: #f5f3ff;
     }
-    .template-futuristic .futuristic-avatar img {
+
+    body.template-futuristic .futuristic-header {
+        background-color: #0b1120;
+        border-bottom: 3px solid {{ $accent }};
+        padding: 24px 32px;
+    }
+
+    body.template-futuristic .futuristic-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-futuristic .futuristic-header td {
+        vertical-align: top;
+    }
+
+    body.template-futuristic .futuristic-avatar {
+        width: 94px;
+        height: 94px;
+        border-radius: 20px;
+        border: 2px solid {{ $accent }};
+        overflow: hidden;
+        background-color: #06080f;
+        box-shadow: 0 0 12px rgba(124, 58, 237, 0.45);
+    }
+
+    body.template-futuristic .futuristic-avatar img {
+        width: 94px;
+        height: 94px;
         object-fit: cover;
     }
-    .template-futuristic .futuristic-avatar-initials {
-        font-size: 22px;
-        font-weight: 600;
-        letter-spacing: 0.35em;
+
+    body.template-futuristic .futuristic-avatar span {
+        display: block;
+        width: 94px;
+        height: 94px;
+        line-height: 94px;
+        text-align: center;
+        font-size: 24px;
+        letter-spacing: 4px;
+        color: {{ $accent }};
     }
-    .template-futuristic .futuristic-name {
-        font-size: 30px;
-        font-weight: 600;
-        color: #f5f3ff;
-    }
-    .template-futuristic .futuristic-headline {
-        margin-top: 8px;
-        font-size: 11px;
-        letter-spacing: 0.45em;
+
+    body.template-futuristic .futuristic-name {
+        font-size: 28px;
+        letter-spacing: 4px;
         text-transform: uppercase;
-        color: #a855f7;
+        margin: 0;
+        color: #f8fafc;
     }
-    .template-futuristic .futuristic-contact {
-        text-align: right;
-        display: grid;
-        gap: 6px;
-        font-size: 11px;
-        color: #c4b5fd;
-    }
-    .template-futuristic .futuristic-grid {
-        display: grid;
-        grid-template-columns: 1.4fr 1fr;
-        gap: 28px;
-    }
-    .template-futuristic .futuristic-section-title {
+
+    body.template-futuristic .futuristic-headline {
         font-size: 12px;
+        letter-spacing: 5px;
         text-transform: uppercase;
-        letter-spacing: 0.4em;
-        color: #a855f7;
-        margin-bottom: 14px;
+        margin-top: 6px;
+        color: #a5b4fc;
     }
-    .template-futuristic .futuristic-card {
-        position: relative;
-        border-radius: 20px;
-        overflow: hidden;
-        padding: 18px 20px;
-        background: rgba(15, 118, 110, 0.1);
-        border: 1px solid rgba(124, 58, 237, 0.3);
-        margin-bottom: 18px;
+
+    body.template-futuristic .futuristic-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        font-size: 11px;
+        color: #cbd5f5;
     }
-    .template-futuristic .futuristic-card:last-child {
+
+    body.template-futuristic .futuristic-contact li {
+        margin-bottom: 4px;
+    }
+
+    body.template-futuristic .futuristic-body {
+        padding: 26px 32px 34px;
+        background: linear-gradient(90deg, rgba(124, 58, 237, 0.08), rgba(34, 211, 238, 0.08));
+    }
+
+    body.template-futuristic .futuristic-summary {
+        border: 1px solid rgba(124, 58, 237, 0.4);
+        background-color: rgba(15, 23, 42, 0.8);
+        border-radius: 18px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
+        font-size: 12px;
+        color: #d0dcff;
+    }
+
+    body.template-futuristic .futuristic-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-futuristic .futuristic-summary p:last-child {
         margin-bottom: 0;
     }
-    .template-futuristic .futuristic-card::before {
-        content: '';
-        position: absolute;
-        inset: 0;
-        background: linear-gradient(120deg, rgba(124, 58, 237, 0.25), transparent 55%);
-        pointer-events: none;
+
+    body.template-futuristic .futuristic-columns {
+        width: 100%;
+        border-collapse: collapse;
     }
-    .template-futuristic .futuristic-card h3 {
-        position: relative;
+
+    body.template-futuristic .futuristic-columns td {
+        vertical-align: top;
+    }
+
+    body.template-futuristic .futuristic-main {
+        width: 65%;
+        padding-right: 22px;
+        border-right: 1px solid rgba(99, 102, 241, 0.25);
+    }
+
+    body.template-futuristic .futuristic-aside {
+        width: 35%;
+        padding-left: 22px;
+    }
+
+    body.template-futuristic .futuristic-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-futuristic .futuristic-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-futuristic .futuristic-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 4px;
+        color: {{ $secondary }};
+        margin-bottom: 10px;
+    }
+
+    body.template-futuristic .futuristic-entry {
+        margin-bottom: 18px;
+        padding-left: 14px;
+        border-left: 3px solid rgba(124, 58, 237, 0.45);
+        background-color: rgba(15, 23, 42, 0.6);
+        border-radius: 6px;
+        padding-bottom: 10px;
+        padding-top: 10px;
+    }
+
+    body.template-futuristic .futuristic-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-futuristic .futuristic-entry-title {
         font-size: 13px;
-        color: #f5f3ff;
+        font-weight: bold;
+        color: #f8fafc;
+    }
+
+    body.template-futuristic .futuristic-meta {
+        font-size: 11px;
+        color: #a5b4fc;
+        margin-top: 4px;
+    }
+
+    body.template-futuristic .futuristic-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-futuristic .futuristic-bullets li {
+        font-size: 12px;
+        color: #d0dcff;
         margin-bottom: 6px;
     }
-    .template-futuristic .futuristic-meta {
-        position: relative;
-        font-size: 11px;
-        color: #c4b5fd;
+
+    body.template-futuristic .futuristic-bullets li:last-child {
+        margin-bottom: 0;
     }
-    .template-futuristic .futuristic-summary {
-        border-radius: 22px;
-        padding: 20px;
-        margin-bottom: 24px;
-        background: linear-gradient(120deg, rgba(124, 58, 237, 0.25), rgba(14, 116, 144, 0.25));
+
+    body.template-futuristic .futuristic-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-futuristic .futuristic-chip-list li {
+        display: inline-block;
+        background-color: rgba(124, 58, 237, 0.15);
         border: 1px solid rgba(124, 58, 237, 0.35);
-        font-size: 12px;
-        color: #ede9fe;
-    }
-    .template-futuristic .futuristic-chiplist {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-    }
-    .template-futuristic .futuristic-chip {
-        padding: 6px 12px;
         border-radius: 999px;
+        padding: 4px 11px;
         font-size: 10px;
-        letter-spacing: 0.32em;
+        letter-spacing: 2px;
         text-transform: uppercase;
-        background: rgba(124, 58, 237, 0.2);
         color: #c4b5fd;
-        border: 1px solid rgba(99, 102, 241, 0.45);
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-futuristic .futuristic-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-futuristic .futuristic-simple-list li {
+        font-size: 11px;
+        color: #d0dcff;
+        margin-bottom: 6px;
+    }
+
+    body.template-futuristic .futuristic-simple-list li span {
+        color: #a5b4fc;
     }
 </style>
-<div class="futuristic-wrapper">
+
+<div class="futuristic-page">
     <header class="futuristic-header">
-        <div class="futuristic-header-main">
-            @if ($profileImage)
-                <div class="futuristic-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div>
-                <h1 class="futuristic-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-                @if ($headline)
-                    <p class="futuristic-headline">{{ strtoupper($headline) }}</p>
+        <table>
+            <tr>
+                <td style="width: 120px;">
+                    <div class="futuristic-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
+                    </div>
+                </td>
+                <td>
+                    <div class="futuristic-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="futuristic-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="futuristic-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
                 @endif
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="futuristic-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
+            </tr>
+        </table>
+    </header>
+
+    <div class="futuristic-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="futuristic-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
             </div>
         @endif
-    </header>
-    <div class="futuristic-grid">
-        <main>
-            @if ($summary)
-                <section class="futuristic-summary">{{ $summary }}</section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section style="margin-bottom: 24px;">
-                    <h2 class="futuristic-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="futuristic-card">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="futuristic-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                            <p class="futuristic-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="position: relative; margin-top: 10px; color: #f1f5f9;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+        <table class="futuristic-columns">
+            <tr>
+                <td class="futuristic-main" @if (! $hasFuturisticAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="futuristic-section">
+                            <div class="futuristic-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="futuristic-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="futuristic-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="futuristic-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="futuristic-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="futuristic-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="futuristic-meta" style="color: #d0dcff; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
 
-            @if (!empty($educationItems))
-                <section>
-                    <h2 class="futuristic-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="futuristic-card">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="futuristic-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                            <p class="futuristic-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section style="margin-bottom: 18px;">
-                    <h2 class="futuristic-section-title">Skills</h2>
-                    <div class="futuristic-chiplist">
-                        @foreach ($skills as $skill)
-                            <span class="futuristic-chip">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="futuristic-section">
+                            <div class="futuristic-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="futuristic-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="futuristic-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="futuristic-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="futuristic-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasFuturisticAside)
+                    <td class="futuristic-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="futuristic-section">
+                                <div class="futuristic-title">{{ __('Skills') }}</div>
+                                <ul class="futuristic-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($languages))
-                <section style="margin-bottom: 18px;">
-                    <h2 class="futuristic-section-title">Languages</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #e2e8f0;">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #a855f7;"> &middot; {{ $language['level'] }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                        @if ($languageItems->isNotEmpty())
+                            <div class="futuristic-section">
+                                <div class="futuristic-title">{{ __('Languages') }}</div>
+                                <ul class="futuristic-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($hobbies))
-                <section>
-                    <h2 class="futuristic-section-title">Interests</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #e2e8f0;">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="futuristic-section">
+                                <div class="futuristic-title">{{ __('Interests') }}</div>
+                                <ul class="futuristic-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 </div>

--- a/resources/views/cv/pdf/templates/gradient.blade.php
+++ b/resources/views/cv/pdf/templates/gradient.blade.php
@@ -1,228 +1,376 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#0ea5e9';
+    $secondary = '#f97316';
+    $hasGradientAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-gradient {
-        background: linear-gradient(160deg, rgba(14, 165, 233, 0.18), rgba(16, 185, 129, 0.18));
-        color: #0f172a;
+    body.template-gradient {
+        background-color: #f1f9ff;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
+        color: #13223a;
     }
-    .template-gradient .gradient-wrapper {
-        width: 100%;
-        background: #ffffff;
-        border-radius: 28px;
-        padding: 32px;
-        border: 1px solid rgba(14, 165, 233, 0.2);
-    }
-    .template-gradient .gradient-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        margin-bottom: 26px;
-    }
-    .template-gradient .gradient-header-main {
-        display: flex;
-        align-items: center;
-        gap: 22px;
-    }
-    .template-gradient .gradient-avatar {
-        width: 82px;
-        height: 82px;
-        border-radius: 24px;
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.22), rgba(16, 185, 129, 0.28));
-        border: 3px solid rgba(14, 165, 233, 0.35);
+
+    body.template-gradient .gradient-page {
+        background-color: #ffffff;
+        border: 2px solid #cdeafe;
+        border-radius: 22px;
         overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: #0f172a;
     }
-    .template-gradient .gradient-avatar img {
+
+    body.template-gradient .gradient-header {
+        background-color: {{ $accent }};
+        color: #ffffff;
+        padding: 26px 32px;
+        border-bottom: 4px solid {{ $secondary }};
+    }
+
+    body.template-gradient .gradient-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-gradient .gradient-header td {
+        vertical-align: top;
+    }
+
+    body.template-gradient .gradient-avatar {
+        width: 96px;
+        height: 96px;
+        border-radius: 24px;
+        border: 3px solid rgba(255, 255, 255, 0.6);
+        overflow: hidden;
+        background-color: rgba(15, 23, 42, 0.25);
+    }
+
+    body.template-gradient .gradient-avatar img {
+        width: 96px;
+        height: 96px;
         object-fit: cover;
     }
-    .template-gradient .gradient-avatar-initials {
-        font-size: 20px;
-        font-weight: 600;
-        letter-spacing: 0.28em;
+
+    body.template-gradient .gradient-avatar span {
+        display: block;
+        width: 96px;
+        height: 96px;
+        line-height: 96px;
+        text-align: center;
+        font-size: 24px;
+        letter-spacing: 4px;
+        color: #ffffff;
     }
-    .template-gradient .gradient-name {
-        font-size: 27px;
-        font-weight: 600;
+
+    body.template-gradient .gradient-name {
+        font-size: 30px;
+        letter-spacing: 3px;
+        text-transform: uppercase;
+        margin: 0;
     }
-    .template-gradient .gradient-headline {
-        margin-top: 8px;
+
+    body.template-gradient .gradient-headline {
         font-size: 12px;
-        letter-spacing: 0.3em;
+        letter-spacing: 4px;
         text-transform: uppercase;
-        color: #0284c7;
+        margin-top: 6px;
+        color: rgba(255, 255, 255, 0.8);
     }
-    .template-gradient .gradient-badge {
-        font-size: 10px;
-        letter-spacing: 0.3em;
-        text-transform: uppercase;
-        color: #0ea5e9;
-    }
-    .template-gradient .gradient-contact {
-        display: grid;
-        gap: 6px;
+
+    body.template-gradient .gradient-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
-        text-align: right;
-        color: #0369a1;
+        color: rgba(255, 255, 255, 0.85);
     }
-    .template-gradient .gradient-grid {
-        display: grid;
-        grid-template-columns: 1.6fr 1fr;
-        gap: 28px;
+
+    body.template-gradient .gradient-contact li {
+        margin-bottom: 4px;
     }
-    .template-gradient .gradient-section-title {
+
+    body.template-gradient .gradient-body {
+        padding: 28px 32px 34px;
+    }
+
+    body.template-gradient .gradient-summary {
+        border: 1px solid #cdeafe;
+        background-color: #ebf8ff;
+        border-radius: 18px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
         font-size: 12px;
-        letter-spacing: 0.32em;
-        text-transform: uppercase;
-        color: #0e7490;
-        margin-bottom: 12px;
+        color: #1b2e44;
     }
-    .template-gradient .gradient-card {
-        border-left: 4px solid rgba(6, 182, 212, 0.4);
-        border-radius: 16px;
-        background: rgba(240, 249, 255, 0.8);
-        padding: 18px 20px;
-        margin-bottom: 16px;
+
+    body.template-gradient .gradient-summary p {
+        margin: 0 0 10px 0;
     }
-    .template-gradient .gradient-card:last-child {
+
+    body.template-gradient .gradient-summary p:last-child {
         margin-bottom: 0;
     }
-    .template-gradient .gradient-card h3 {
-        font-size: 13px;
-        font-weight: 600;
-        color: #0f172a;
+
+    body.template-gradient .gradient-columns {
+        width: 100%;
+        border-collapse: collapse;
     }
-    .template-gradient .gradient-meta {
+
+    body.template-gradient .gradient-columns td {
+        vertical-align: top;
+    }
+
+    body.template-gradient .gradient-main {
+        width: 65%;
+        padding-right: 22px;
+        border-right: 1px solid #d7ecff;
+    }
+
+    body.template-gradient .gradient-aside {
+        width: 35%;
+        padding-left: 22px;
+    }
+
+    body.template-gradient .gradient-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-gradient .gradient-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-gradient .gradient-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: {{ $secondary }};
+        margin-bottom: 10px;
+    }
+
+    body.template-gradient .gradient-entry {
+        margin-bottom: 18px;
+        padding-left: 12px;
+        border-left: 3px solid rgba(14, 165, 233, 0.35);
+    }
+
+    body.template-gradient .gradient-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-gradient .gradient-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #13223a;
+    }
+
+    body.template-gradient .gradient-meta {
         font-size: 11px;
-        color: #0e7490;
+        color: #355072;
         margin-top: 4px;
     }
-    .template-gradient .gradient-summary {
-        background: linear-gradient(135deg, rgba(14, 165, 233, 0.15), rgba(16, 185, 129, 0.15));
-        border: 1px solid rgba(14, 165, 233, 0.25);
-        border-radius: 16px;
-        padding: 18px;
+
+    body.template-gradient .gradient-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-gradient .gradient-bullets li {
         font-size: 12px;
-        margin-bottom: 24px;
+        color: #1b2e44;
+        margin-bottom: 6px;
     }
-    .template-gradient .gradient-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 6px;
+
+    body.template-gradient .gradient-bullets li:last-child {
+        margin-bottom: 0;
     }
-    .template-gradient .gradient-tag {
-        padding: 5px 10px;
+
+    body.template-gradient .gradient-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-gradient .gradient-chip-list li {
+        display: inline-block;
+        background-color: rgba(14, 165, 233, 0.12);
+        border: 1px solid rgba(14, 165, 233, 0.3);
         border-radius: 12px;
+        padding: 4px 11px;
         font-size: 10px;
-        letter-spacing: 0.25em;
+        letter-spacing: 2px;
         text-transform: uppercase;
-        background: rgba(16, 185, 129, 0.15);
-        color: #0f766e;
+        color: #0f4c75;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-gradient .gradient-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-gradient .gradient-simple-list li {
+        font-size: 11px;
+        color: #1b2e44;
+        margin-bottom: 6px;
+    }
+
+    body.template-gradient .gradient-simple-list li span {
+        color: #355072;
     }
 </style>
-<div class="gradient-wrapper">
+
+<div class="gradient-page">
     <header class="gradient-header">
-        <div class="gradient-header-main">
-            @if ($profileImage)
-                <div class="gradient-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div>
-                <div class="gradient-badge">Profile</div>
-                <h1 class="gradient-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-                @if ($headline)
-                    <p class="gradient-headline">{{ strtoupper($headline) }}</p>
+        <table>
+            <tr>
+                <td style="width: 120px;">
+                    <div class="gradient-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
+                    </div>
+                </td>
+                <td>
+                    <div class="gradient-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="gradient-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="gradient-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
                 @endif
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="gradient-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
+            </tr>
+        </table>
+    </header>
+
+    <div class="gradient-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="gradient-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
             </div>
         @endif
-    </header>
-    <div class="gradient-grid">
-        <main>
-            @if ($summary)
-                <section class="gradient-summary">{{ $summary }}</section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section style="margin-bottom: 24px;">
-                    <h2 class="gradient-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="gradient-card">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="gradient-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                            <p class="gradient-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="margin-top: 10px; color: #134e4a;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+        <table class="gradient-columns">
+            <tr>
+                <td class="gradient-main" @if (! $hasGradientAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="gradient-section">
+                            <div class="gradient-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="gradient-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="gradient-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="gradient-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="gradient-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="gradient-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="gradient-meta" style="color: #1b2e44; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
 
-            @if (!empty($educationItems))
-                <section>
-                    <h2 class="gradient-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="gradient-card">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="gradient-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                            <p class="gradient-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section style="margin-bottom: 18px;">
-                    <h2 class="gradient-section-title">Skills</h2>
-                    <div class="gradient-tags">
-                        @foreach ($skills as $skill)
-                            <span class="gradient-tag">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="gradient-section">
+                            <div class="gradient-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="gradient-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="gradient-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="gradient-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="gradient-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasGradientAside)
+                    <td class="gradient-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="gradient-section">
+                                <div class="gradient-title">{{ __('Skills') }}</div>
+                                <ul class="gradient-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($languages))
-                <section style="margin-bottom: 18px;">
-                    <h2 class="gradient-section-title">Languages</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #0f172a;">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #0ea5e9;"> &middot; {{ $language['level'] }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                        @if ($languageItems->isNotEmpty())
+                            <div class="gradient-section">
+                                <div class="gradient-title">{{ __('Languages') }}</div>
+                                <ul class="gradient-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($hobbies))
-                <section>
-                    <h2 class="gradient-section-title">Interests</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #0f172a;">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="gradient-section">
+                                <div class="gradient-title">{{ __('Interests') }}</div>
+                                <ul class="gradient-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 </div>

--- a/resources/views/cv/pdf/templates/minimal.blade.php
+++ b/resources/views/cv/pdf/templates/minimal.blade.php
@@ -1,219 +1,365 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#0f172a';
+    $hasMinimalAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-minimal {
-        background: #ffffff;
-    }
-    .template-minimal .minimal-wrapper {
-        width: 100%;
-        padding: 24px 28px;
-    }
-    .template-minimal .minimal-header {
-        margin-bottom: 26px;
-    }
-    .template-minimal .minimal-header-main {
-        display: flex;
-        align-items: center;
-        gap: 24px;
-    }
-    .template-minimal .minimal-avatar {
-        width: 74px;
-        height: 74px;
-        border-radius: 999px;
-        border: 2px solid rgba(100, 116, 139, 0.3);
-        background: rgba(15, 23, 42, 0.05);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+    body.template-minimal {
+        background-color: #f4f7fb;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
         color: #0f172a;
     }
-    .template-minimal .minimal-avatar img {
+
+    body.template-minimal .minimal-page {
+        background-color: #ffffff;
+        border: 1px solid #d6deeb;
+        border-radius: 18px;
+        padding: 28px 32px;
+    }
+
+    body.template-minimal .minimal-header {
+        border-bottom: 1px solid #d6deeb;
+        padding-bottom: 18px;
+        margin-bottom: 22px;
+    }
+
+    body.template-minimal .minimal-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-minimal .minimal-header td {
+        vertical-align: top;
+    }
+
+    body.template-minimal .minimal-avatar {
+        width: 90px;
+        height: 90px;
+        border-radius: 12px;
+        border: 2px solid #d6deeb;
+        overflow: hidden;
+        background-color: #f1f5f9;
+    }
+
+    body.template-minimal .minimal-avatar img {
+        width: 90px;
+        height: 90px;
         object-fit: cover;
     }
-    .template-minimal .minimal-avatar-initials {
-        font-size: 20px;
-        font-weight: 500;
-        letter-spacing: 0.22em;
-    }
-    .template-minimal .minimal-name {
-        font-size: 28px;
-        font-weight: 500;
-        letter-spacing: 0.02em;
-        color: #0f172a;
-    }
-    .template-minimal .minimal-headline {
-        margin-top: 8px;
-        font-size: 12px;
-        letter-spacing: 0.38em;
-        text-transform: uppercase;
+
+    body.template-minimal .minimal-avatar span {
+        display: block;
+        width: 90px;
+        height: 90px;
+        line-height: 90px;
+        text-align: center;
+        font-size: 22px;
+        letter-spacing: 4px;
         color: #475569;
     }
-    .template-minimal .minimal-contact {
-        margin-top: 16px;
-        display: grid;
-        gap: 4px;
+
+    body.template-minimal .minimal-name {
+        font-size: 26px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        margin: 0;
+    }
+
+    body.template-minimal .minimal-headline {
+        font-size: 12px;
+        letter-spacing: 4px;
+        text-transform: uppercase;
+        margin-top: 6px;
+        color: #64748b;
+    }
+
+    body.template-minimal .minimal-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
         color: #475569;
     }
-    .template-minimal .minimal-grid {
-        display: grid;
-        grid-template-columns: 1.7fr 1fr;
-        gap: 32px;
-    }
-    .template-minimal .minimal-section-title {
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.4em;
-        color: #64748b;
-        margin-bottom: 10px;
-    }
-    .template-minimal .minimal-divider {
-        height: 1px;
-        background: rgba(148, 163, 184, 0.5);
-        margin: 18px 0;
-    }
-    .template-minimal .minimal-item {
-        margin-bottom: 18px;
-    }
-    .template-minimal .minimal-item:last-child {
-        margin-bottom: 0;
-    }
-    .template-minimal .minimal-item h3 {
-        font-size: 13px;
-        font-weight: 500;
-        color: #0f172a;
+
+    body.template-minimal .minimal-contact li {
         margin-bottom: 4px;
     }
-    .template-minimal .minimal-meta {
-        font-size: 11px;
-        color: #94a3b8;
-    }
-    .template-minimal .minimal-summary {
+
+    body.template-minimal .minimal-summary {
+        border-left: 4px solid {{ $accent }};
+        background-color: #f8fafc;
+        padding: 14px 18px;
+        margin-bottom: 24px;
         font-size: 12px;
         color: #1f2937;
+    }
+
+    body.template-minimal .minimal-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-minimal .minimal-summary p:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-minimal .minimal-columns {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-minimal .minimal-columns td {
+        vertical-align: top;
+    }
+
+    body.template-minimal .minimal-main {
+        width: 67%;
+        padding-right: 20px;
+        border-right: 1px solid #e2e8f0;
+    }
+
+    body.template-minimal .minimal-aside {
+        width: 33%;
+        padding-left: 20px;
+    }
+
+    body.template-minimal .minimal-section {
         margin-bottom: 24px;
     }
-    .template-minimal .minimal-bullet {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        font-size: 11px;
-        color: #334155;
+
+    body.template-minimal .minimal-section:last-child {
+        margin-bottom: 0;
     }
-    .template-minimal .minimal-dot {
-        width: 4px;
-        height: 4px;
+
+    body.template-minimal .minimal-title {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: #475569;
+        margin-bottom: 8px;
+    }
+
+    body.template-minimal .minimal-entry {
+        margin-bottom: 16px;
+    }
+
+    body.template-minimal .minimal-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-minimal .minimal-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #0f172a;
+    }
+
+    body.template-minimal .minimal-meta {
+        font-size: 11px;
+        color: #64748b;
+        margin-top: 4px;
+    }
+
+    body.template-minimal .minimal-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
+    }
+
+    body.template-minimal .minimal-bullets li {
+        font-size: 12px;
+        color: #1f2937;
+        margin-bottom: 6px;
+    }
+
+    body.template-minimal .minimal-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-minimal .minimal-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-minimal .minimal-chip-list li {
+        display: inline-block;
+        background-color: #f1f5f9;
+        border: 1px solid #e2e8f0;
         border-radius: 999px;
-        background: #475569;
+        padding: 4px 10px;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        color: #475569;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-minimal .minimal-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-minimal .minimal-simple-list li {
+        font-size: 11px;
+        color: #1f2937;
+        margin-bottom: 6px;
+    }
+
+    body.template-minimal .minimal-simple-list li span {
+        color: #64748b;
     }
 </style>
-<div class="minimal-wrapper">
+
+<div class="minimal-page">
     <header class="minimal-header">
-        <div class="minimal-header-main">
-            @if ($profileImage)
-                <div class="minimal-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div>
-                <h1 class="minimal-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-                @if ($headline)
-                    <p class="minimal-headline">{{ strtoupper($headline) }}</p>
+        <table>
+            <tr>
+                <td style="width: 110px;">
+                    <div class="minimal-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
+                    </div>
+                </td>
+                <td>
+                    <div class="minimal-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="minimal-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="minimal-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
                 @endif
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="minimal-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
-                @endforeach
-            </div>
-        @endif
+            </tr>
+        </table>
     </header>
-    <div class="minimal-grid">
-        <main>
-            @if ($summary)
-                <section class="minimal-summary">{{ $summary }}</section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section>
-                    <h2 class="minimal-section-title">Experience</h2>
-                    <div class="minimal-divider"></div>
-                    @foreach ($experienceItems as $experience)
-                        <article class="minimal-item">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="minimal-meta">{{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}</p>
-                            <p class="minimal-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="margin-top: 10px; color: #1f2937;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+    @if ($summaryParagraphs->isNotEmpty())
+        <div class="minimal-summary">
+            @foreach ($summaryParagraphs as $paragraph)
+                <p>{{ $paragraph }}</p>
+            @endforeach
+        </div>
+    @endif
 
-            @if (!empty($educationItems))
-                <section style="margin-top: 28px;">
-                    <h2 class="minimal-section-title">Education</h2>
-                    <div class="minimal-divider"></div>
-                    @foreach ($educationItems as $education)
-                        <article class="minimal-item">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="minimal-meta">{{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}</p>
-                            <p class="minimal-meta">{{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}</p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section>
-                    <h2 class="minimal-section-title">Skills</h2>
-                    <div class="minimal-divider"></div>
-                    <ul style="display: grid; gap: 6px;">
-                        @foreach ($skills as $skill)
-                            <li class="minimal-bullet"><span class="minimal-dot"></span>{{ $skill }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-
-            @if (!empty($languages))
-                <section style="margin-top: 28px;">
-                    <h2 class="minimal-section-title">Languages</h2>
-                    <div class="minimal-divider"></div>
-                    <ul style="display: grid; gap: 6px;">
-                        @foreach ($languages as $language)
-                            <li class="minimal-bullet">
-                                <span class="minimal-dot"></span>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #94a3b8;">&nbsp;{{ $language['level'] }}</span>
+    <table class="minimal-columns">
+        <tr>
+            <td class="minimal-main" @if (! $hasMinimalAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                @if ($experienceBlocks->isNotEmpty())
+                    <div class="minimal-section">
+                        <div class="minimal-title">{{ __('Experience') }}</div>
+                        @foreach ($experienceBlocks as $experience)
+                            <div class="minimal-entry">
+                                @if (!empty($experience['position']))
+                                    <div class="minimal-entry-title">{{ $experience['position'] }}</div>
                                 @endif
-                            </li>
+                                @php
+                                    $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                    $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                @endphp
+                                @if ($metaPieces->isNotEmpty())
+                                    <div class="minimal-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($timePieces->isNotEmpty())
+                                    <div class="minimal-meta">{{ $timePieces->implode(' – ') }}</div>
+                                @endif
+                                @if ($experience['bullets']->isNotEmpty())
+                                    <ul class="minimal-bullets">
+                                        @foreach ($experience['bullets'] as $bullet)
+                                            <li>{{ $bullet }}</li>
+                                        @endforeach
+                                    </ul>
+                                @elseif (!empty($experience['achievements']))
+                                    <p class="minimal-meta" style="color: #1f2937; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                @endif
+                            </div>
                         @endforeach
-                    </ul>
-                </section>
-            @endif
+                    </div>
+                @endif
 
-            @if (!empty($hobbies))
-                <section style="margin-top: 28px;">
-                    <h2 class="minimal-section-title">Interests</h2>
-                    <div class="minimal-divider"></div>
-                    <ul style="display: grid; gap: 6px;">
-                        @foreach ($hobbies as $hobby)
-                            <li class="minimal-bullet"><span class="minimal-dot"></span>{{ $hobby }}</li>
+                @if ($educationBlocks->isNotEmpty())
+                    <div class="minimal-section">
+                        <div class="minimal-title">{{ __('Education') }}</div>
+                        @foreach ($educationBlocks as $education)
+                            <div class="minimal-entry">
+                                @if (!empty($education['institution']))
+                                    <div class="minimal-entry-title">{{ $education['institution'] }}</div>
+                                @endif
+                                @php
+                                    $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                    $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                    $locationPieces = collect([$education['location'] ?? null])->filter();
+                                @endphp
+                                @if ($studyPieces->isNotEmpty())
+                                    <div class="minimal-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                @endif
+                                @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                    <div class="minimal-meta">
+                                        {{ $locationPieces->implode(' · ') }}
+                                        @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                            ·
+                                        @endif
+                                        {{ $durationPieces->implode(' – ') }}
+                                    </div>
+                                @endif
+                            </div>
                         @endforeach
-                    </ul>
-                </section>
+                    </div>
+                @endif
+            </td>
+            @if ($hasMinimalAside)
+                <td class="minimal-aside">
+                    @if ($skillTags->isNotEmpty())
+                        <div class="minimal-section">
+                            <div class="minimal-title">{{ __('Skills') }}</div>
+                            <ul class="minimal-chip-list">
+                                @foreach ($skillTags as $skill)
+                                    <li>{{ $skill }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($languageItems->isNotEmpty())
+                        <div class="minimal-section">
+                            <div class="minimal-title">{{ __('Languages') }}</div>
+                            <ul class="minimal-simple-list">
+                                @foreach ($languageItems as $language)
+                                    <li>
+                                        {{ $language['name'] }}
+                                        @if ($language['level'])
+                                            <span>· {{ $language['level'] }}</span>
+                                        @endif
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+
+                    @if ($hobbyItems->isNotEmpty())
+                        <div class="minimal-section">
+                            <div class="minimal-title">{{ __('Interests') }}</div>
+                            <ul class="minimal-simple-list">
+                                @foreach ($hobbyItems as $hobby)
+                                    <li>{{ $hobby }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endif
+                </td>
             @endif
-        </aside>
-    </div>
+        </tr>
+    </table>
 </div>

--- a/resources/views/cv/pdf/templates/modern.blade.php
+++ b/resources/views/cv/pdf/templates/modern.blade.php
@@ -1,235 +1,374 @@
+@include('cv.pdf.templates.partials.data-prep')
+
+@php
+    $accent = $accentColor ?? '#2563eb';
+    $hasModernAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
+@endphp
+
 <style>
-    .template-modern {
-        background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(14, 165, 233, 0.12));
+    body.template-modern {
+        background-color: #eef3ff;
+        padding: 18px;
+        font-family: 'DejaVu Sans', 'Helvetica', 'Arial', sans-serif;
+        color: #0f172a;
     }
-    .template-modern .modern-wrapper {
-        width: 100%;
-        background: #ffffff;
-        border-radius: 24px;
+
+    body.template-modern .modern-page {
+        background-color: #ffffff;
+        border: 1px solid #cbd5f5;
+        border-radius: 20px;
+        padding: 0;
         overflow: hidden;
-        border: 1px solid rgba(37, 99, 235, 0.2);
     }
-    .template-modern .modern-header {
-        background: {{ $accentColor }};
+
+    body.template-modern .modern-header {
+        background-color: {{ $accent }};
         color: #ffffff;
-        padding: 28px 32px;
+        padding: 22px 28px;
     }
-    .template-modern .modern-header-top {
-        display: flex;
-        align-items: center;
-        gap: 24px;
-    }
-    .template-modern .modern-avatar {
-        width: 84px;
-        height: 84px;
-        border-radius: 999px;
-        border: 3px solid rgba(255, 255, 255, 0.55);
-        overflow: hidden;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: rgba(15, 23, 42, 0.2);
-        color: #ffffff;
-    }
-    .template-modern .modern-avatar img {
+
+    body.template-modern .modern-header table {
         width: 100%;
-        height: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-modern .modern-header td {
+        vertical-align: top;
+    }
+
+    body.template-modern .modern-avatar {
+        width: 90px;
+        height: 90px;
+        border-radius: 50px;
+        border: 3px solid rgba(255, 255, 255, 0.5);
+        overflow: hidden;
+        background-color: rgba(15, 23, 42, 0.25);
+    }
+
+    body.template-modern .modern-avatar img {
+        width: 90px;
+        height: 90px;
         object-fit: cover;
     }
-    .template-modern .modern-avatar-initials {
-        font-size: 22px;
-        font-weight: 600;
-        letter-spacing: 0.18em;
+
+    body.template-modern .modern-avatar span {
+        display: block;
+        width: 90px;
+        height: 90px;
+        line-height: 90px;
+        text-align: center;
+        font-size: 24px;
+        letter-spacing: 5px;
+        color: #ffffff;
     }
-    .template-modern .modern-name {
-        font-size: 28px;
-        font-weight: 600;
-        letter-spacing: 0.01em;
-    }
-    .template-modern .modern-headline {
-        font-size: 13px;
-        margin-top: 6px;
-        letter-spacing: 0.18em;
+
+    body.template-modern .modern-name {
+        font-size: 27px;
+        letter-spacing: 3px;
         text-transform: uppercase;
-        color: rgba(255, 255, 255, 0.72);
+        margin: 0;
     }
-    .template-modern .modern-contact {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 16px;
-        margin-top: 18px;
+
+    body.template-modern .modern-headline {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        margin-top: 6px;
+        color: rgba(255, 255, 255, 0.78);
+    }
+
+    body.template-modern .modern-contact {
+        list-style: none;
+        margin: 0;
+        padding: 0;
         font-size: 11px;
     }
-    .template-modern .modern-body {
-        display: grid;
-        grid-template-columns: 1.6fr 1fr;
-        gap: 28px;
-        padding: 28px 32px;
-    }
-    .template-modern .modern-section-title {
-        font-size: 13px;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.26em;
-        color: #0f172a;
-        margin-bottom: 12px;
-    }
-    .template-modern .modern-summary {
-        background: rgba(37, 99, 235, 0.08);
-        border: 1px solid rgba(37, 99, 235, 0.18);
-        padding: 18px;
-        border-radius: 18px;
-        font-size: 12px;
-        color: #1f2937;
-        margin-bottom: 24px;
-    }
-    .template-modern .modern-card {
-        border: 1px solid #e2e8f0;
-        border-radius: 16px;
-        padding: 16px 18px;
-        margin-bottom: 16px;
-    }
-    .template-modern .modern-card:last-child {
-        margin-bottom: 0;
-    }
-    .template-modern .modern-card h3 {
-        font-size: 13px;
-        font-weight: 600;
-        color: #0f172a;
+
+    body.template-modern .modern-contact li {
         margin-bottom: 4px;
     }
-    .template-modern .modern-meta {
+
+    body.template-modern .modern-body {
+        padding: 26px 30px 28px;
+    }
+
+    body.template-modern .modern-summary {
+        background-color: rgba(37, 99, 235, 0.08);
+        border: 1px solid rgba(37, 99, 235, 0.2);
+        border-radius: 14px;
+        padding: 16px 18px;
+        margin-bottom: 24px;
+        font-size: 12px;
+        color: #1f2937;
+    }
+
+    body.template-modern .modern-summary p {
+        margin: 0 0 10px 0;
+    }
+
+    body.template-modern .modern-summary p:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-modern .modern-columns {
+        width: 100%;
+        border-collapse: collapse;
+    }
+
+    body.template-modern .modern-columns td {
+        vertical-align: top;
+    }
+
+    body.template-modern .modern-main {
+        width: 66%;
+        padding-right: 18px;
+        border-right: 1px solid #d9e2ff;
+    }
+
+    body.template-modern .modern-aside {
+        width: 34%;
+        padding-left: 18px;
+    }
+
+    body.template-modern .modern-section {
+        margin-bottom: 26px;
+    }
+
+    body.template-modern .modern-section:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-modern .modern-title {
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 3px;
+        color: {{ $accent }};
+        margin-bottom: 10px;
+    }
+
+    body.template-modern .modern-entry {
+        border-left: 3px solid rgba(37, 99, 235, 0.35);
+        padding-left: 12px;
+        margin-bottom: 18px;
+    }
+
+    body.template-modern .modern-entry:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-modern .modern-entry-title {
+        font-size: 13px;
+        font-weight: bold;
+        color: #0f172a;
+    }
+
+    body.template-modern .modern-meta {
         font-size: 11px;
         color: #475569;
+        margin-top: 4px;
     }
-    .template-modern .modern-aside-card {
-        border: 1px solid rgba(15, 23, 42, 0.12);
-        border-radius: 18px;
-        padding: 18px;
-        margin-bottom: 18px;
-        background: rgba(15, 23, 42, 0.02);
+
+    body.template-modern .modern-bullets {
+        margin: 10px 0 0 16px;
+        padding: 0;
     }
-    .template-modern .modern-chiplist {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
+
+    body.template-modern .modern-bullets li {
+        font-size: 12px;
+        color: #1f2937;
+        margin-bottom: 6px;
     }
-    .template-modern .modern-chip {
-        padding: 5px 12px;
-        border-radius: 999px;
-        font-size: 10px;
-        text-transform: uppercase;
-        letter-spacing: 0.2em;
-        background: rgba(37, 99, 235, 0.12);
+
+    body.template-modern .modern-bullets li:last-child {
+        margin-bottom: 0;
+    }
+
+    body.template-modern .modern-chip-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-modern .modern-chip-list li {
+        display: inline-block;
+        background-color: rgba(37, 99, 235, 0.12);
+        border: 1px solid rgba(37, 99, 235, 0.3);
         color: #1d4ed8;
+        border-radius: 999px;
+        padding: 4px 11px;
+        font-size: 10px;
+        letter-spacing: 2px;
+        text-transform: uppercase;
+        margin: 0 6px 6px 0;
+    }
+
+    body.template-modern .modern-simple-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    body.template-modern .modern-simple-list li {
+        font-size: 11px;
+        color: #1f2937;
+        margin-bottom: 6px;
+    }
+
+    body.template-modern .modern-simple-list li span {
+        color: #64748b;
     }
 </style>
-<div class="modern-wrapper">
+
+<div class="modern-page">
     <header class="modern-header">
-        <div class="modern-header-top">
-            @if ($profileImage)
-                <div class="modern-avatar">
-                    <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                </div>
-            @endif
-            <div>
-                <h1 class="modern-name">{{ $fullName ?: 'Curriculum Vitae' }}</h1>
-                @if ($headline)
-                    <p class="modern-headline">{{ strtoupper($headline) }}</p>
+        <table>
+            <tr>
+                <td style="width: 110px;">
+                    <div class="modern-avatar">
+                        @if ($profileImage)
+                            <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
+                        @elseif ($initials)
+                            <span>{{ $initials }}</span>
+                        @else
+                            <span>{{ __('CV') }}</span>
+                        @endif
+                    </div>
+                </td>
+                <td>
+                    <div class="modern-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
+                    @if ($headline)
+                        <div class="modern-headline">{{ strtoupper($headline) }}</div>
+                    @endif
+                </td>
+                @if (!empty($contactItems))
+                    <td style="width: 220px;">
+                        <ul class="modern-contact">
+                            @foreach ($contactItems as $contact)
+                                <li>{{ $contact }}</li>
+                            @endforeach
+                        </ul>
+                    </td>
                 @endif
-            </div>
-        </div>
-        @if (!empty($contactItems))
-            <div class="modern-contact">
-                @foreach ($contactItems as $contact)
-                    <span>{{ $contact }}</span>
+            </tr>
+        </table>
+    </header>
+
+    <div class="modern-body">
+        @if ($summaryParagraphs->isNotEmpty())
+            <div class="modern-summary">
+                @foreach ($summaryParagraphs as $paragraph)
+                    <p>{{ $paragraph }}</p>
                 @endforeach
             </div>
         @endif
-    </header>
-    <div class="modern-body">
-        <main>
-            @if ($summary)
-                <section class="modern-summary">{{ $summary }}</section>
-            @endif
 
-            @if (!empty($experienceItems))
-                <section style="margin-bottom: 24px;">
-                    <h2 class="modern-section-title">Experience</h2>
-                    @foreach ($experienceItems as $experience)
-                        <article class="modern-card">
-                            @if ($experience['position'])
-                                <h3>{{ $experience['position'] }}</h3>
-                            @endif
-                            <p class="modern-meta">
-                                {{ collect([$experience['company'], $experience['location']])->filter()->implode(' · ') }}
-                            </p>
-                            <p class="modern-meta">{{ collect([$experience['from'], $experience['to']])->filter()->implode(' – ') }}</p>
-                            @if ($experience['achievements'])
-                                <p style="margin-top: 10px; color: #1f2937;">{{ $experience['achievements'] }}</p>
-                            @endif
-                        </article>
-                    @endforeach
-                </section>
-            @endif
+        <table class="modern-columns">
+            <tr>
+                <td class="modern-main" @if (! $hasModernAside) style="width: 100%; padding-right: 0; border-right: none;" @endif>
+                    @if ($experienceBlocks->isNotEmpty())
+                        <div class="modern-section">
+                            <div class="modern-title">{{ __('Experience') }}</div>
+                            @foreach ($experienceBlocks as $experience)
+                                <div class="modern-entry">
+                                    @if (!empty($experience['position']))
+                                        <div class="modern-entry-title">{{ $experience['position'] }}</div>
+                                    @endif
+                                    @php
+                                        $metaPieces = collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter();
+                                        $timePieces = collect([$experience['from'] ?? null, $experience['to'] ?? null])->filter();
+                                    @endphp
+                                    @if ($metaPieces->isNotEmpty())
+                                        <div class="modern-meta">{{ $metaPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($timePieces->isNotEmpty())
+                                        <div class="modern-meta">{{ $timePieces->implode(' – ') }}</div>
+                                    @endif
+                                    @if ($experience['bullets']->isNotEmpty())
+                                        <ul class="modern-bullets">
+                                            @foreach ($experience['bullets'] as $bullet)
+                                                <li>{{ $bullet }}</li>
+                                            @endforeach
+                                        </ul>
+                                    @elseif (!empty($experience['achievements']))
+                                        <p class="modern-meta" style="color: #1f2937; margin-top: 8px;">{{ $experience['achievements'] }}</p>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
 
-            @if (!empty($educationItems))
-                <section>
-                    <h2 class="modern-section-title">Education</h2>
-                    @foreach ($educationItems as $education)
-                        <article class="modern-card">
-                            @if ($education['institution'])
-                                <h3>{{ $education['institution'] }}</h3>
-                            @endif
-                            <p class="modern-meta">
-                                {{ collect([$education['degree'], $education['field']])->filter()->implode(' · ') }}
-                            </p>
-                            <p class="modern-meta">
-                                {{ collect([$education['location'], collect([$education['start'], $education['end'] ?: __('Ongoing')])->filter()->implode(' – ')])->filter()->implode(' · ') }}
-                            </p>
-                        </article>
-                    @endforeach
-                </section>
-            @endif
-        </main>
-        <aside>
-            @if (!empty($skills))
-                <section class="modern-aside-card">
-                    <h2 class="modern-section-title" style="margin-bottom: 16px;">Skills</h2>
-                    <div class="modern-chiplist">
-                        @foreach ($skills as $skill)
-                            <span class="modern-chip">{{ $skill }}</span>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
+                    @if ($educationBlocks->isNotEmpty())
+                        <div class="modern-section">
+                            <div class="modern-title">{{ __('Education') }}</div>
+                            @foreach ($educationBlocks as $education)
+                                <div class="modern-entry">
+                                    @if (!empty($education['institution']))
+                                        <div class="modern-entry-title">{{ $education['institution'] }}</div>
+                                    @endif
+                                    @php
+                                        $studyPieces = collect([$education['degree'] ?? null, $education['field'] ?? null])->filter();
+                                        $durationPieces = collect([$education['start'] ?? null, $education['end'] ?? __('Ongoing')])->filter();
+                                        $locationPieces = collect([$education['location'] ?? null])->filter();
+                                    @endphp
+                                    @if ($studyPieces->isNotEmpty())
+                                        <div class="modern-meta">{{ $studyPieces->implode(' · ') }}</div>
+                                    @endif
+                                    @if ($locationPieces->isNotEmpty() || $durationPieces->isNotEmpty())
+                                        <div class="modern-meta">
+                                            {{ $locationPieces->implode(' · ') }}
+                                            @if ($locationPieces->isNotEmpty() && $durationPieces->isNotEmpty())
+                                                ·
+                                            @endif
+                                            {{ $durationPieces->implode(' – ') }}
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </td>
+                @if ($hasModernAside)
+                    <td class="modern-aside">
+                        @if ($skillTags->isNotEmpty())
+                            <div class="modern-section">
+                                <div class="modern-title">{{ __('Skills') }}</div>
+                                <ul class="modern-chip-list">
+                                    @foreach ($skillTags as $skill)
+                                        <li>{{ $skill }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($languages))
-                <section class="modern-aside-card">
-                    <h2 class="modern-section-title" style="margin-bottom: 12px;">Languages</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #1f2937;">
-                        @foreach ($languages as $language)
-                            <li>
-                                {{ $language['name'] }}
-                                @if ($language['level'])
-                                    <span style="color: #64748b;"> &middot; {{ $language['level'] }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                        @if ($languageItems->isNotEmpty())
+                            <div class="modern-section">
+                                <div class="modern-title">{{ __('Languages') }}</div>
+                                <ul class="modern-simple-list">
+                                    @foreach ($languageItems as $language)
+                                        <li>
+                                            {{ $language['name'] }}
+                                            @if ($language['level'])
+                                                <span>· {{ $language['level'] }}</span>
+                                            @endif
+                                        </li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
 
-            @if (!empty($hobbies))
-                <section class="modern-aside-card">
-                    <h2 class="modern-section-title" style="margin-bottom: 12px;">Interests</h2>
-                    <ul style="display: grid; gap: 6px; font-size: 11px; color: #1f2937;">
-                        @foreach ($hobbies as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
+                        @if ($hobbyItems->isNotEmpty())
+                            <div class="modern-section">
+                                <div class="modern-title">{{ __('Interests') }}</div>
+                                <ul class="modern-simple-list">
+                                    @foreach ($hobbyItems as $hobby)
+                                        <li>{{ $hobby }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+                        @endif
+                    </td>
+                @endif
+            </tr>
+        </table>
     </div>
 </div>

--- a/resources/views/cv/pdf/templates/partials/data-prep.blade.php
+++ b/resources/views/cv/pdf/templates/partials/data-prep.blade.php
@@ -1,0 +1,77 @@
+@php
+    $summaryParagraphs = collect(preg_split('/\r\n|\r|\n/', (string) ($summary ?? '')))
+        ->map(fn ($line) => trim((string) $line))
+        ->filter()
+        ->values();
+
+    $achievementLines = function ($text) {
+        return collect(preg_split('/\r\n|\r|\n|•|‣|▪|\u2022|\u25CF|\u25CB|\u25AA|\u25AB|\u25A0|\u25A1|\u2023|\u2043|\-/u', (string) ($text ?? '')))
+            ->map(function ($line) {
+                $line = trim((string) $line);
+                if ($line === '') {
+                    return null;
+                }
+
+                $line = preg_replace('/^[\p{Pd}\s•‣▪\u2022\u25CF\u25CB\u25AA\u25AB\u25A0\u25A1\u2023\u2043]+/u', '', $line);
+
+                return trim((string) $line);
+            })
+            ->filter()
+            ->values();
+    };
+
+    $experienceBlocks = collect($experienceItems ?? [])
+        ->map(function ($item) use ($achievementLines) {
+            if (!is_array($item)) {
+                $item = (array) $item;
+            }
+
+            $item['bullets'] = $achievementLines($item['achievements'] ?? null);
+
+            return $item;
+        })
+        ->filter(function ($item) {
+            return !empty($item['position']) || !empty($item['company']) || !empty($item['achievements']);
+        })
+        ->values();
+
+    $educationBlocks = collect($educationItems ?? [])
+        ->map(function ($item) {
+            if (!is_array($item)) {
+                $item = (array) $item;
+            }
+
+            return $item;
+        })
+        ->filter(function ($item) {
+            return !empty($item['institution']) || !empty($item['degree']) || !empty($item['field']);
+        })
+        ->values();
+
+    $skillTags = collect($skills ?? [])
+        ->map(fn ($item) => trim((string) $item))
+        ->filter()
+        ->values();
+
+    $languageItems = collect($languages ?? [])
+        ->map(function ($item) {
+            if (!is_array($item)) {
+                $item = (array) $item;
+            }
+
+            $name = trim((string) ($item['name'] ?? ($item[0] ?? '')));
+            $level = trim((string) ($item['level'] ?? ($item[1] ?? '')));
+
+            return [
+                'name' => $name,
+                'level' => $level,
+            ];
+        })
+        ->filter(fn ($item) => $item['name'] !== '')
+        ->values();
+
+    $hobbyItems = collect($hobbies ?? [])
+        ->map(fn ($item) => trim((string) $item))
+        ->filter()
+        ->values();
+@endphp


### PR DESCRIPTION
## Summary
- add a shared data-preparation partial so every PDF template receives normalized collections for summaries, lists, and achievements
- redesign each PDF resume template with table-based, Dompdf-friendly layouts and refreshed styling that prevents overlapping content
- ensure every template gracefully handles missing avatars while presenting experience, education, skills, languages, and interests in distinct sections

## Testing
- php artisan test *(fails: vendor directory is not present in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df7c73bcc883329dab337efe52244c