### PR TITLE
Fix PCRE2 bullet splitting regex

### DIFF
--- a/resources/views/cv/pdf/templates/partials/data-prep.blade.php
+++ b/resources/views/cv/pdf/templates/partials/data-prep.blade.php
@@ -5,14 +5,14 @@
         ->values();
 
     $achievementLines = function ($text) {
-        return collect(preg_split('/\r\n|\r|\n|•|‣|▪|\u2022|\u25CF|\u25CB|\u25AA|\u25AB|\u25A0|\u25A1|\u2023|\u2043|\-/u', (string) ($text ?? '')))
+        return collect(preg_split('/\r\n|\r|\n|•|‣|▪|\x{2022}|\x{25CF}|\x{25CB}|\x{25AA}|\x{25AB}|\x{25A0}|\x{25A1}|\x{2023}|\x{2043}|\-/u', (string) ($text ?? '')))
             ->map(function ($line) {
                 $line = trim((string) $line);
                 if ($line === '') {
                     return null;
                 }
 
-                $line = preg_replace('/^[\p{Pd}\s•‣▪\u2022\u25CF\u25CB\u25AA\u25AB\u25A0\u25A1\u2023\u2043]+/u', '', $line);
+                $line = preg_replace('/^[\p{Pd}\s•‣▪\x{2022}\x{25CF}\x{25CB}\x{25AA}\x{25AB}\x{25A0}\x{25A1}\x{2023}\x{2043}]+/u', '', $line);
 
                 return trim((string) $line);
             })


### PR DESCRIPTION
## Summary
- update the PDF data preparation helper to use PCRE2-compatible Unicode escapes when splitting achievement text
- ensure leading bullet characters are stripped with the same PCRE2-compatible escape sequences

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23dd3a43c8332a5ec5856429ad6fb