### PR TITLE
Handle missing data prep collections in classic PDF template

### DIFF
--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -1,6 +1,10 @@
 @include('cv.pdf.templates.partials.data-prep')
 
 @php
+    $skillTags = ($skillTags ?? collect())->filter();
+    $languageItems = ($languageItems ?? collect())->filter();
+    $hobbyItems = ($hobbyItems ?? collect())->filter();
+
     $hasClassicAside = $skillTags->isNotEmpty() || $languageItems->isNotEmpty() || $hobbyItems->isNotEmpty();
 @endphp
 


### PR DESCRIPTION
## Summary
- ensure the classic PDF template always has collection instances for skills, languages, and hobbies
- prevent undefined variable errors when rendering the classic template without the data-prep partial output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e23e728e748332a8ebc5aa2f9ab0ef