### PR TITLE
Inline profile photos in template data

### DIFF
--- a/tests/Unit/TemplateDataBuilderTest.php
+++ b/tests/Unit/TemplateDataBuilderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\View\TemplateDataBuilder;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class TemplateDataBuilderTest extends TestCase
+{
+    public function test_it_base64_encodes_profile_image_from_public_disk(): void
+    {
+        Storage::fake('public');
+
+        $imageContents = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBAp3xmwAAAABJRU5ErkJggg==');
+        $this->assertNotFalse($imageContents);
+        Storage::disk('public')->put('cv-photos/example.png', $imageContents);
+
+        $data = TemplateDataBuilder::fromCv([
+            'first_name' => 'Ada',
+            'last_name' => 'Lovelace',
+            'profile_image' => 'cv-photos/example.png',
+        ]);
+
+        $this->assertArrayHasKey('profile_image', $data);
+        $this->assertNotNull($data['profile_image']);
+        $this->assertStringStartsWith('data:image/png;base64,', $data['profile_image']);
+        $this->assertStringContainsString(base64_encode($imageContents), $data['profile_image']);
+    }
+}


### PR DESCRIPTION
## Summary
- convert stored profile image paths into data URIs when building template data so profile photos render reliably
- add a unit test covering the data URI conversion for stored profile images

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e247205e6083328a5b287a89a467ae