### PR TITLE
Fix profile image handling for stored public URLs

### DIFF
--- a/tests/Unit/TemplateDataBuilderTest.php
+++ b/tests/Unit/TemplateDataBuilderTest.php
@@ -27,4 +27,26 @@ class TemplateDataBuilderTest extends TestCase
         $this->assertStringStartsWith('data:image/png;base64,', $data['profile_image']);
         $this->assertStringContainsString(base64_encode($imageContents), $data['profile_image']);
     }
+
+    public function test_it_base64_encodes_profile_image_when_absolute_public_url_provided(): void
+    {
+        Storage::fake('public');
+
+        $imageContents = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBAp3xmwAAAABJRU5ErkJggg==');
+        $this->assertNotFalse($imageContents);
+        Storage::disk('public')->put('cv-photos/example.png', $imageContents);
+
+        $absoluteUrl = 'https://app.example/storage/cv-photos/example.png';
+
+        $data = TemplateDataBuilder::fromCv([
+            'first_name' => 'Ada',
+            'last_name' => 'Lovelace',
+            'profile_image' => $absoluteUrl,
+        ]);
+
+        $this->assertArrayHasKey('profile_image', $data);
+        $this->assertNotNull($data['profile_image']);
+        $this->assertStringStartsWith('data:image/png;base64,', $data['profile_image']);
+        $this->assertStringContainsString(base64_encode($imageContents), $data['profile_image']);
+    }
 }


### PR DESCRIPTION
## Summary
- resolve stored profile photos from the public disk even when referenced via absolute URLs
- ensure preview and PDF rendering reuse the disk path to embed profile images as base64 data URIs
- add unit coverage for absolute public URLs when building template data

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24991237c833294ab9fc8ba2dc21d