### PR TITLE
Hide profile photo when not provided

### DIFF
--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -213,17 +213,13 @@
 <div class="classic-page">
     <table class="classic-header">
         <tr>
-            <td style="width: 110px;">
-                <div class="classic-avatar">
-                    @if ($profileImage)
+            @if ($profileImage)
+                <td style="width: 110px;">
+                    <div class="classic-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                    @elseif ($initials)
-                        <span>{{ $initials }}</span>
-                    @else
-                        <span>{{ __('CV') }}</span>
-                    @endif
-                </div>
-            </td>
+                    </div>
+                </td>
+            @endif
             <td>
                 <div class="classic-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                 @if ($headline)

--- a/resources/views/cv/pdf/templates/corporate.blade.php
+++ b/resources/views/cv/pdf/templates/corporate.blade.php
@@ -220,17 +220,13 @@
     <header class="corporate-header">
         <table>
             <tr>
-                <td style="width: 120px;">
-                    <div class="corporate-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 120px;">
+                        <div class="corporate-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="corporate-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/creative.blade.php
+++ b/resources/views/cv/pdf/templates/creative.blade.php
@@ -236,17 +236,13 @@
     <header class="creative-header">
         <table>
             <tr>
-                <td style="width: 110px;">
-                    <div class="creative-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 110px;">
+                        <div class="creative-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="creative-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/darkmode.blade.php
+++ b/resources/views/cv/pdf/templates/darkmode.blade.php
@@ -223,17 +223,13 @@
     <header class="dark-header">
         <table>
             <tr>
-                <td style="width: 120px;">
-                    <div class="dark-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 120px;">
+                        <div class="dark-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="dark-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/elegant.blade.php
+++ b/resources/views/cv/pdf/templates/elegant.blade.php
@@ -216,17 +216,13 @@
     <header class="elegant-header">
         <table>
             <tr>
-                <td style="width: 120px;">
-                    <div class="elegant-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 120px;">
+                        <div class="elegant-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="elegant-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/futuristic.blade.php
+++ b/resources/views/cv/pdf/templates/futuristic.blade.php
@@ -229,17 +229,13 @@
     <header class="futuristic-header">
         <table>
             <tr>
-                <td style="width: 120px;">
-                    <div class="futuristic-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 120px;">
+                        <div class="futuristic-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="futuristic-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/gradient.blade.php
+++ b/resources/views/cv/pdf/templates/gradient.blade.php
@@ -223,17 +223,13 @@
     <header class="gradient-header">
         <table>
             <tr>
-                <td style="width: 120px;">
-                    <div class="gradient-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 120px;">
+                        <div class="gradient-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="gradient-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/minimal.blade.php
+++ b/resources/views/cv/pdf/templates/minimal.blade.php
@@ -214,17 +214,13 @@
     <header class="minimal-header">
         <table>
             <tr>
-                <td style="width: 110px;">
-                    <div class="minimal-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 110px;">
+                        <div class="minimal-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="minimal-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/pdf/templates/modern.blade.php
+++ b/resources/views/cv/pdf/templates/modern.blade.php
@@ -221,17 +221,13 @@
     <header class="modern-header">
         <table>
             <tr>
-                <td style="width: 110px;">
-                    <div class="modern-avatar">
-                        @if ($profileImage)
+                @if ($profileImage)
+                    <td style="width: 110px;">
+                        <div class="modern-avatar">
                             <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}">
-                        @elseif ($initials)
-                            <span>{{ $initials }}</span>
-                        @else
-                            <span>{{ __('CV') }}</span>
-                        @endif
-                    </div>
-                </td>
+                        </div>
+                    </td>
+                @endif
                 <td>
                     <div class="modern-name">{{ $fullName ?: 'Curriculum Vitae' }}</div>
                     @if ($headline)

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -248,13 +248,11 @@
                     <div>
                         <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Overview') }}</p>
                         <div class="mt-4 flex flex-col gap-6 sm:flex-row sm:items-start">
-                            <div class="flex h-24 w-24 flex-shrink-0 items-center justify-center overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 text-2xl font-semibold text-slate-600 shadow-sm">
-                                @if ($profileImage)
+                            @if ($profileImage)
+                                <div class="flex h-24 w-24 flex-shrink-0 items-center justify-center overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 text-2xl font-semibold text-slate-600 shadow-sm">
                                     <img src="{{ $profileImage }}" alt="{{ $fullName ?: __('Profile photo') }}" class="h-full w-full object-cover">
-                                @else
-                                    <span>{{ $initials }}</span>
-                                @endif
-                            </div>
+                                </div>
+                            @endif
                             <div class="flex-1">
                                 <h1 class="text-3xl font-semibold text-slate-900">{{ $fullName ?: __('Untitled CV') }}</h1>
                                 @if ($headline)


### PR DESCRIPTION
## Summary
- stop rendering the avatar block in the live CV preview when no profile photo exists
- conditionally render the profile photo column across all PDF templates so empty placeholders are never shown

## Testing
- php artisan test *(fails: missing vendor directory in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e24c7ec94c8332af403a61cf31590e