### PR TITLE
Render template previews using inline PDFs

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -358,7 +358,11 @@
     }
 
     .createit-template-card__preview {
-        @apply relative h-52 overflow-hidden rounded-t-[28px] bg-gradient-to-br;
+        @apply relative h-72 overflow-hidden rounded-t-[28px] bg-white;
+    }
+
+    .createit-template-card__preview-frame {
+        @apply h-full w-full border-0;
     }
 
     .createit-template-card__badge {

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -56,54 +56,6 @@
                 'partial' => 'templates.previews.futuristic',
             ],
         ];
-
-        $sampleCv = [
-            'first_name' => 'Jordan',
-            'last_name' => 'Rivera',
-            'headline' => 'Product Designer',
-            'email' => 'jordan.rivera@example.com',
-            'phone' => '+1 (555) 123-4567',
-            'city' => 'Toronto',
-            'country' => 'Canada',
-            'summary' => 'Designer blending research, motion, and storytelling to craft delightful digital experiences.',
-            'work_experience' => [
-                [
-                    'position' => 'Senior Product Designer',
-                    'company' => 'Northwind Studio',
-                    'city' => 'Toronto',
-                    'country' => 'Canada',
-                    'from' => '2021-02',
-                    'currently' => true,
-                    'achievements' => 'Led cross-functional sprints and launched a design system that lifted activation by 28%.',
-                ],
-                [
-                    'position' => 'Product Designer',
-                    'company' => 'Aurora Labs',
-                    'city' => 'Vancouver',
-                    'country' => 'Canada',
-                    'from' => '2018-05',
-                    'to' => '2021-01',
-                    'achievements' => 'Prototyped immersive flows that increased retention across mobile and web surfaces.',
-                ],
-            ],
-            'education' => [
-                [
-                    'degree' => 'B.A. Interaction Design',
-                    'institution' => 'University of British Columbia',
-                    'city' => 'Vancouver',
-                    'country' => 'Canada',
-                    'start_year' => '2014',
-                    'end_year' => '2018',
-                    'field' => 'Design & Technology',
-                ],
-            ],
-            'skills' => ['Design Systems', 'User Research', 'Prototyping', 'Motion'],
-            'languages' => [
-                ['name' => 'English', 'level' => 'native'],
-                ['name' => 'French', 'level' => 'advanced'],
-            ],
-            'hobbies' => ['Gallery hopping', 'Cycling', 'Synth music'],
-        ];
     @endphp
 
     <div class="space-y-10">
@@ -127,10 +79,15 @@
                     ];
                 @endphp
                 <div class="group createit-template-card">
-                    <div class="createit-template-card__preview bg-gradient-to-br {{ $meta['preview'] }}">
-                        @isset($meta['partial'])
-                            @include($meta['partial'])
-                        @endisset
+                    <div class="createit-template-card__preview">
+                        <iframe
+                            src="{{ route('cv.template-preview', $template) }}#toolbar=0&navpanes=0&scrollbar=0"
+                            title="{{ __('Preview of the :template template', ['template' => $meta['title']]) }}"
+                            class="createit-template-card__preview-frame"
+                            loading="lazy"
+                        >
+                            {{ __('PDF preview of the :template template.', ['template' => $meta['title']]) }}
+                        </iframe>
                     </div>
                     <div class="createit-template-card__body">
                         <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -46,6 +46,7 @@ Route::middleware('auth')->group(function () {
 
 Route::prefix('cv')->controller(CvController::class)->group(function () {
     Route::get('/templates','templates')->name('cv.templates');
+    Route::get('/templates/{template}/preview','templatePreview')->name('cv.template-preview');
     Route::get('/download','download')->name('cv.download');
 });
 


### PR DESCRIPTION
## Summary
- add a dedicated template preview endpoint that renders sample CV data as PDFs
- allow the PDF renderer to stream inline content and wire it to the template gallery view
- update the gallery styling so PDF iframes fit within the template cards

## Testing
- ./vendor/bin/phpunit *(fails: vendor binaries missing because Composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24e9b19748332b88302407669247b