### PR TITLE
Align header and column layout across CV templates

### DIFF
--- a/public/templates/css/corporate.css
+++ b/public/templates/css/corporate.css
@@ -34,18 +34,17 @@ body.corporate-template {
 .corporate-header {
     background: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(56, 189, 248, 0.85));
     border-radius: 28px;
-    padding: 48px 56px;
+    padding: 56px 64px 48px;
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: 32px;
+    justify-content: center;
     color: #f8fafc;
     box-shadow: 0 40px 90px rgba(14, 165, 233, 0.22);
+    text-align: center;
 }
 
-.corporate-header__identity {
+.corporate-header__inner {
     display: flex;
+    flex-direction: column;
     align-items: center;
     gap: 24px;
 }
@@ -70,6 +69,13 @@ body.corporate-template {
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+
+.corporate-header__identity {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
 }
 
 .corporate-label {
@@ -97,25 +103,38 @@ body.corporate-template {
     opacity: 0.85;
 }
 
-.corporate-header__contact {
-    display: grid;
-    gap: 10px;
+.corporate-header__meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 8px;
     font-size: 13px;
-    letter-spacing: 0.16em;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
     opacity: 0.85;
 }
 
-.corporate-grid {
+.corporate-layout {
     display: grid;
-    grid-template-columns: 1.1fr 1.5fr 1fr;
-    gap: 32px;
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+    gap: 36px;
 }
 
-.corporate-column {
+.corporate-side,
+.corporate-main {
     display: flex;
     flex-direction: column;
     gap: 28px;
+}
+
+.corporate-side {
+    border-right: 1px solid var(--corporate-border);
+    padding-right: 24px;
+}
+
+.corporate-main {
+    padding-left: 24px;
 }
 
 .corporate-panel {
@@ -201,43 +220,16 @@ body.corporate-template {
 
 .corporate-list--divider li:last-child {
     border-bottom: none;
-    padding-bottom: 0;
 }
 
 .corporate-milestones {
     display: grid;
-    gap: 24px;
-    position: relative;
-    padding-left: 28px;
-}
-
-.corporate-milestones::before {
-    content: "";
-    position: absolute;
-    left: 6px;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    background: var(--corporate-border);
+    gap: 20px;
 }
 
 .corporate-milestone {
-    position: relative;
     display: grid;
     gap: 10px;
-    padding-bottom: 4px;
-}
-
-.corporate-milestone::before {
-    content: "";
-    position: absolute;
-    left: -24px;
-    top: 6px;
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    border: 2px solid var(--corporate-accent);
-    background: #fff;
 }
 
 .corporate-milestone__meta {
@@ -245,7 +237,7 @@ body.corporate-template {
     flex-wrap: wrap;
     gap: 12px;
     font-size: 12px;
-    letter-spacing: 0.12em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
     color: var(--corporate-muted);
 }
@@ -257,48 +249,40 @@ body.corporate-template {
 
 .corporate-milestone__content h3 {
     margin: 0;
-    font-size: 20px;
-    font-family: 'Barlow Condensed', sans-serif;
-    letter-spacing: 0.08em;
+    font-size: 18px;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
 }
 
 .corporate-milestone__content p {
-    margin: 8px 0 0;
+    margin: 0;
     color: var(--corporate-muted);
 }
 
 .corporate-education {
     display: grid;
-    gap: 16px;
+    gap: 18px;
 }
 
 .corporate-education article {
-    border-radius: 20px;
-    border: 1px solid var(--corporate-border);
-    padding: 18px 20px;
-    background: linear-gradient(135deg, rgba(14, 165, 233, 0.1), rgba(255, 255, 255, 0.95));
     display: grid;
     gap: 10px;
-}
-
-.corporate-education h3 {
-    margin: 0;
-    font-family: 'Barlow Condensed', sans-serif;
-    font-size: 18px;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
 }
 
 .corporate-education__meta {
     display: flex;
     justify-content: space-between;
-    align-items: baseline;
-    gap: 12px;
+    align-items: center;
+    gap: 16px;
     font-size: 12px;
-    letter-spacing: 0.12em;
     text-transform: uppercase;
+    letter-spacing: 0.1em;
     color: var(--corporate-muted);
+}
+
+.corporate-education__meta span:first-child {
+    font-weight: 600;
+    color: var(--corporate-ink);
 }
 
 .corporate-education p {
@@ -306,17 +290,25 @@ body.corporate-template {
     color: var(--corporate-muted);
 }
 
-@media (max-width: 1120px) {
+@media (max-width: 1024px) {
     body.corporate-template {
         padding: 32px;
     }
 
-    .corporate-grid {
+    .corporate-layout {
         grid-template-columns: 1fr;
+        gap: 28px;
     }
 
-    .corporate-header {
-        border-radius: 24px;
+    .corporate-side {
+        border-right: none;
+        padding-right: 0;
+        border-bottom: 1px solid var(--corporate-border);
+        padding-bottom: 24px;
+    }
+
+    .corporate-main {
+        padding-left: 0;
     }
 }
 
@@ -326,11 +318,6 @@ body.corporate-template {
     }
 
     .corporate-header {
-        padding: 40px;
-    }
-
-    .corporate-header__identity {
-        flex-direction: column;
-        align-items: flex-start;
+        padding: 48px 32px;
     }
 }

--- a/public/templates/css/elegant.css
+++ b/public/templates/css/elegant.css
@@ -38,14 +38,12 @@ body.elegant-template {
 
 .elegant-hero {
     position: relative;
-    padding: 56px 64px;
+    padding: 64px 72px 56px;
     background: linear-gradient(130deg, rgba(157, 23, 77, 0.9), rgba(76, 29, 149, 0.85));
     color: #fff;
     display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-    gap: 32px;
+    justify-content: center;
+    text-align: center;
 }
 
 .elegant-hero::after {
@@ -56,14 +54,11 @@ body.elegant-template {
     pointer-events: none;
 }
 
-.elegant-hero__identity,
-.elegant-hero__contact {
+.elegant-hero__inner {
     position: relative;
     z-index: 1;
-}
-
-.elegant-hero__identity {
     display: flex;
+    flex-direction: column;
     align-items: center;
     gap: 28px;
 }
@@ -87,6 +82,13 @@ body.elegant-template {
     width: 100%;
     height: 100%;
     object-fit: cover;
+}
+
+.elegant-hero__identity {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
 }
 
 .elegant-label {
@@ -113,27 +115,30 @@ body.elegant-template {
     opacity: 0.85;
 }
 
-.elegant-hero__contact {
+.elegant-hero__meta {
     display: flex;
-    flex-direction: column;
-    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-top: 4px;
     font-size: 13px;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
-    opacity: 0.9;
+    opacity: 0.85;
 }
 
 .elegant-body {
     display: grid;
-    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
     gap: 32px;
     padding: 56px 64px 72px;
     background: linear-gradient(180deg, rgba(253, 242, 248, 0.65), rgba(255, 255, 255, 0));
     flex: 1;
+    align-items: start;
 }
 
-.elegant-primary,
-.elegant-secondary {
+.elegant-secondary,
+.elegant-primary {
     display: flex;
     flex-direction: column;
     gap: 32px;
@@ -376,6 +381,14 @@ body.elegant-template {
     .elegant-body {
         grid-template-columns: 1fr;
     }
+
+    .elegant-secondary {
+        order: 1;
+    }
+
+    .elegant-primary {
+        order: 2;
+    }
 }
 
 @media (max-width: 720px) {
@@ -384,19 +397,14 @@ body.elegant-template {
     }
 
     .elegant-hero {
-        padding: 40px;
-    }
-
-    .elegant-hero__identity {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .elegant-hero__contact {
-        width: 100%;
+        padding: 48px 32px;
     }
 
     .elegant-body {
         padding: 40px 32px 48px;
+    }
+
+    .elegant-card {
+        padding: 28px 24px;
     }
 }

--- a/public/templates/css/minimal.css
+++ b/public/templates/css/minimal.css
@@ -24,9 +24,6 @@ body.minimal-template {
 }
 
 .minimal-wrapper {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    gap: 40px;
     max-width: 1080px;
     margin: 0 auto;
     background: #fff;
@@ -34,85 +31,96 @@ body.minimal-template {
     overflow: hidden;
     box-shadow: 0 40px 80px rgba(15, 23, 42, 0.08);
     border: 1px solid rgba(15, 23, 42, 0.08);
-}
-
-.minimal-sidebar {
-    background: linear-gradient(180deg, rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.78));
-    color: #f8fafc;
-    padding: 48px 36px;
     display: flex;
     flex-direction: column;
-    gap: 36px;
 }
 
-.minimal-identity {
-    display: grid;
-    gap: 16px;
+.minimal-header {
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.96), rgba(30, 41, 59, 0.85));
+    color: #f8fafc;
+    padding: 56px 48px 48px;
+    text-align: center;
 }
 
-.minimal-avatar {
-    width: 104px;
-    height: 104px;
-    border-radius: 28px;
+.minimal-header__inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+}
+
+.minimal-header__avatar {
+    width: 112px;
+    height: 112px;
+    border-radius: 32px;
     overflow: hidden;
     border: 2px solid rgba(248, 250, 252, 0.4);
     display: grid;
     place-items: center;
-    font-size: 28px;
+    font-size: 32px;
     font-weight: 600;
     color: rgba(248, 250, 252, 0.9);
     background: rgba(148, 163, 184, 0.25);
 }
 
-.minimal-avatar img {
+.minimal-header__avatar img {
     width: 100%;
     height: 100%;
     object-fit: cover;
 }
 
-.minimal-avatar--initials {
+.minimal-header__avatar--initials {
     letter-spacing: 0.08em;
 }
 
-.minimal-identity__text h1 {
+.minimal-header__identity h1 {
     margin: 0;
-    font-size: 26px;
-    letter-spacing: 0.05em;
+    font-size: 32px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
 }
 
-.minimal-headline {
+.minimal-header__headline {
     margin: 8px 0 0;
     font-size: 13px;
     letter-spacing: 0.28em;
     text-transform: uppercase;
+    color: rgba(226, 232, 240, 0.82);
+}
+
+.minimal-header__meta {
+    margin-top: 16px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 14px;
+    font-size: 13px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
     color: rgba(226, 232, 240, 0.8);
 }
 
-.minimal-contact {
-    margin: 0;
+.minimal-layout {
     display: grid;
-    gap: 12px;
-    font-size: 13px;
+    grid-template-columns: minmax(220px, 320px) minmax(0, 1fr);
+    gap: 48px;
+    padding: 48px 56px 64px;
 }
 
-.minimal-contact div {
-    display: grid;
-    gap: 4px;
+.minimal-column {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
 }
 
-.minimal-contact dt {
-    margin: 0;
-    font-weight: 600;
-    letter-spacing: 0.24em;
-    text-transform: uppercase;
-    color: rgba(226, 232, 240, 0.6);
+.minimal-column--left {
+    border-right: 1px solid var(--minimal-soft);
+    padding-right: 32px;
 }
 
-.minimal-contact dd {
-    margin: 0;
-    color: rgba(241, 245, 249, 0.92);
-    word-break: break-word;
+.minimal-column--right {
+    padding-left: 32px;
+    gap: 40px;
 }
 
 .minimal-sidebar-section h2 {
@@ -120,7 +128,7 @@ body.minimal-template {
     font-size: 12px;
     letter-spacing: 0.3em;
     text-transform: uppercase;
-    color: rgba(226, 232, 240, 0.7);
+    color: var(--minimal-accent);
 }
 
 .minimal-sidebar-section ul {
@@ -128,14 +136,15 @@ body.minimal-template {
     margin: 0;
     padding: 0;
     display: grid;
-    gap: 8px;
+    gap: 10px;
 }
 
 .minimal-sidebar-section li {
     display: flex;
     justify-content: space-between;
     gap: 8px;
-    color: rgba(226, 232, 240, 0.9);
+    color: var(--minimal-muted);
+    font-size: 13px;
 }
 
 .minimal-pill-list {
@@ -145,28 +154,23 @@ body.minimal-template {
 }
 
 .minimal-pill-list li {
-    background: rgba(226, 232, 240, 0.16);
+    background: rgba(226, 232, 240, 0.45);
     border-radius: 999px;
     padding: 4px 12px;
     font-size: 12px;
     letter-spacing: 0.12em;
     text-transform: uppercase;
+    color: var(--minimal-accent);
 }
 
 .minimal-badge {
-    background: rgba(226, 232, 240, 0.16);
+    background: rgba(226, 232, 240, 0.45);
     border-radius: 999px;
     padding: 2px 8px;
     font-size: 11px;
     letter-spacing: 0.16em;
     text-transform: uppercase;
-}
-
-.minimal-content {
-    padding: 48px 56px;
-    display: flex;
-    flex-direction: column;
-    gap: 40px;
+    color: var(--minimal-accent);
 }
 
 .minimal-section {
@@ -192,6 +196,8 @@ body.minimal-template {
 .minimal-section--summary {
     border-left: 4px solid var(--minimal-accent);
     padding-left: 24px;
+    background: linear-gradient(135deg, rgba(226, 232, 240, 0.25), rgba(255, 255, 255, 0.9));
+    border-radius: 18px;
 }
 
 .minimal-timeline {
@@ -295,16 +301,21 @@ body.minimal-template {
         padding: 24px;
     }
 
-    .minimal-wrapper {
+    .minimal-layout {
         grid-template-columns: 1fr;
-    }
-
-    .minimal-sidebar {
-        padding: 40px 32px;
-    }
-
-    .minimal-content {
+        gap: 32px;
         padding: 40px 32px 48px;
+    }
+
+    .minimal-column--left {
+        border-right: none;
+        padding-right: 0;
+        border-bottom: 1px solid var(--minimal-soft);
+        padding-bottom: 24px;
+    }
+
+    .minimal-column--right {
+        padding-left: 0;
     }
 
     .minimal-timeline {

--- a/resources/views/templates/corporate.blade.php
+++ b/resources/views/templates/corporate.blade.php
@@ -22,7 +22,7 @@
 
     <div class="corporate-report">
         <header class="corporate-header">
-            <div class="corporate-header__identity">
+            <div class="corporate-header__inner">
                 @if ($profileImage)
                     <div class="corporate-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
@@ -30,37 +30,28 @@
                 @elseif ($initials)
                     <div class="corporate-avatar corporate-avatar--initials">{{ $initials }}</div>
                 @endif
-                <div>
+                <div class="corporate-header__identity">
                     <p class="corporate-label">{{ __('Executive Profile') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
                         <p class="corporate-headline">{{ $data['headline'] }}</p>
                     @endif
+                    @if (($data['location'] ?? null) || ($data['phone'] ?? null))
+                        <div class="corporate-header__meta">
+                            @if ($data['location'] ?? null)
+                                <span>{{ $data['location'] }}</span>
+                            @endif
+                            @if ($data['phone'] ?? null)
+                                <span>{{ $data['phone'] }}</span>
+                            @endif
+                        </div>
+                    @endif
                 </div>
             </div>
-
-            @if (!empty($data['contacts']))
-                <div class="corporate-header__contact">
-                    @foreach ($data['contacts'] as $contact)
-                        <span>{{ $contact }}</span>
-                    @endforeach
-                </div>
-            @endif
         </header>
 
-        <div class="corporate-grid">
-            <aside class="corporate-column corporate-column--left">
-                @if ($summaryParagraphs->isNotEmpty())
-                    <section class="corporate-panel corporate-panel--summary">
-                        <h2>{{ __('Leadership Narrative') }}</h2>
-                        <div class="corporate-panel__body">
-                            @foreach ($summaryParagraphs as $paragraph)
-                                <p>{{ $paragraph }}</p>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-
+        <div class="corporate-layout">
+            <aside class="corporate-side">
                 @if (!empty($data['skills']))
                     <section class="corporate-panel">
                         <h2>{{ __('Core Competencies') }}</h2>
@@ -69,61 +60,6 @@
                                 <li>{{ $skill }}</li>
                             @endforeach
                         </ul>
-                    </section>
-                @endif
-            </aside>
-
-            <main class="corporate-column corporate-column--center">
-                @if (!empty($data['experiences']))
-                    <section class="corporate-panel">
-                        <header class="corporate-panel__header">
-                            <h2>{{ __('Experience Highlights') }}</h2>
-                            <p>{{ __('Guiding organisations through transformation and growth.') }}</p>
-                        </header>
-                        <div class="corporate-milestones">
-                            @foreach ($data['experiences'] as $experience)
-                                <article class="corporate-milestone">
-                                    <div class="corporate-milestone__meta">
-                                        @if ($experience['period'])
-                                            <span class="corporate-milestone__period">{{ $experience['period'] }}</span>
-                                        @endif
-                                        <span class="corporate-milestone__company">{{ collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter()->implode(' · ') }}</span>
-                                    </div>
-                                    <div class="corporate-milestone__content">
-                                        @if ($experience['role'])
-                                            <h3>{{ $experience['role'] }}</h3>
-                                        @endif
-                                        @if ($experience['summary'])
-                                            <p>{{ $experience['summary'] }}</p>
-                                        @endif
-                                    </div>
-                                </article>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-            </main>
-
-            <aside class="corporate-column corporate-column--right">
-                @if (!empty($data['education']))
-                    <section class="corporate-panel">
-                        <h2>{{ __('Education') }}</h2>
-                        <div class="corporate-education">
-                            @foreach ($data['education'] as $education)
-                                <article>
-                                    <h3>{{ $education['institution'] }}</h3>
-                                    <div class="corporate-education__meta">
-                                        <span>{{ collect([$education['degree'] ?? null, $education['field'] ?? null])->filter()->implode(' · ') }}</span>
-                                        @if ($education['period'])
-                                            <span>{{ $education['period'] }}</span>
-                                        @endif
-                                    </div>
-                                    @if ($education['location'])
-                                        <p>{{ $education['location'] }}</p>
-                                    @endif
-                                </article>
-                            @endforeach
-                        </div>
                     </section>
                 @endif
 
@@ -154,6 +90,70 @@
                     </section>
                 @endif
             </aside>
+
+            <main class="corporate-main">
+                @if ($summaryParagraphs->isNotEmpty())
+                    <section class="corporate-panel corporate-panel--summary">
+                        <h2>{{ __('Leadership Narrative') }}</h2>
+                        <div class="corporate-panel__body">
+                            @foreach ($summaryParagraphs as $paragraph)
+                                <p>{{ $paragraph }}</p>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                @if (!empty($data['experiences']))
+                    <section class="corporate-panel">
+                        <header class="corporate-panel__header">
+                            <h2>{{ __('Experience Highlights') }}</h2>
+                            <p>{{ __('Guiding organisations through transformation and growth.') }}</p>
+                        </header>
+                        <div class="corporate-milestones">
+                            @foreach ($data['experiences'] as $experience)
+                                <article class="corporate-milestone">
+                                    <div class="corporate-milestone__meta">
+                                        @if ($experience['period'])
+                                            <span class="corporate-milestone__period">{{ $experience['period'] }}</span>
+                                        @endif
+                                        <span class="corporate-milestone__company">{{ collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter()->implode(' · ') }}</span>
+                                    </div>
+                                    <div class="corporate-milestone__content">
+                                        @if ($experience['role'])
+                                            <h3>{{ $experience['role'] }}</h3>
+                                        @endif
+                                        @if ($experience['summary'])
+                                            <p>{{ $experience['summary'] }}</p>
+                                        @endif
+                                    </div>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+
+                @if (!empty($data['education']))
+                    <section class="corporate-panel">
+                        <h2>{{ __('Education') }}</h2>
+                        <div class="corporate-education">
+                            @foreach ($data['education'] as $education)
+                                <article>
+                                    <h3>{{ $education['institution'] }}</h3>
+                                    <div class="corporate-education__meta">
+                                        <span>{{ collect([$education['degree'] ?? null, $education['field'] ?? null])->filter()->implode(' · ') }}</span>
+                                        @if ($education['period'])
+                                            <span>{{ $education['period'] }}</span>
+                                        @endif
+                                    </div>
+                                    @if ($education['location'])
+                                        <p>{{ $education['location'] }}</p>
+                                    @endif
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+            </main>
         </div>
     </div>
 </body>

--- a/resources/views/templates/elegant.blade.php
+++ b/resources/views/templates/elegant.blade.php
@@ -22,7 +22,7 @@
 
     <div class="elegant-document">
         <header class="elegant-hero">
-            <div class="elegant-hero__identity">
+            <div class="elegant-hero__inner">
                 @if ($profileImage)
                     <figure class="elegant-avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
@@ -30,25 +30,67 @@
                 @elseif ($initials)
                     <figure class="elegant-avatar elegant-avatar--initials">{{ $initials }}</figure>
                 @endif
-                <div>
+                <div class="elegant-hero__identity">
                     <p class="elegant-label">{{ __('Curriculum Vitae') }}</p>
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
                         <p class="elegant-headline">{{ $data['headline'] }}</p>
                     @endif
+                    @if (($data['location'] ?? null) || ($data['phone'] ?? null))
+                        <div class="elegant-hero__meta">
+                            @if ($data['location'] ?? null)
+                                <span>{{ $data['location'] }}</span>
+                            @endif
+                            @if ($data['phone'] ?? null)
+                                <span>{{ $data['phone'] }}</span>
+                            @endif
+                        </div>
+                    @endif
                 </div>
             </div>
-
-            @if (!empty($data['contacts']))
-                <div class="elegant-hero__contact">
-                    @foreach ($data['contacts'] as $contact)
-                        <span>{{ $contact }}</span>
-                    @endforeach
-                </div>
-            @endif
         </header>
 
         <div class="elegant-body">
+            <aside class="elegant-secondary">
+                @if (!empty($data['skills']))
+                    <section class="elegant-aside-card">
+                        <h2>{{ __('Competencies') }}</h2>
+                        <ul class="elegant-tag-list">
+                            @foreach ($data['skills'] as $skill)
+                                <li>{{ $skill }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <section class="elegant-aside-card">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul class="elegant-language-list">
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    <span>{{ $language['name'] }}</span>
+                                    @if (!empty($language['level']))
+                                        <span>{{ ucfirst($language['level']) }}</span>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <section class="elegant-aside-card">
+                        <h2>{{ __('Interests') }}</h2>
+                        <ul class="elegant-interest-list">
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+            </aside>
+
             <main class="elegant-primary">
                 @if ($summaryParagraphs->isNotEmpty())
                     <section class="elegant-card elegant-summary">
@@ -115,46 +157,6 @@
                     </section>
                 @endif
             </main>
-
-            <aside class="elegant-secondary">
-                @if (!empty($data['skills']))
-                    <section class="elegant-aside-card">
-                        <h2>{{ __('Competencies') }}</h2>
-                        <ul class="elegant-tag-list">
-                            @foreach ($data['skills'] as $skill)
-                                <li>{{ $skill }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
-                @if (!empty($data['languages']))
-                    <section class="elegant-aside-card">
-                        <h2>{{ __('Languages') }}</h2>
-                        <ul class="elegant-language-list">
-                            @foreach ($data['languages'] as $language)
-                                <li>
-                                    <span>{{ $language['name'] }}</span>
-                                    @if (!empty($language['level']))
-                                        <span>{{ ucfirst($language['level']) }}</span>
-                                    @endif
-                                </li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-
-                @if (!empty($data['hobbies']))
-                    <section class="elegant-aside-card">
-                        <h2>{{ __('Interests') }}</h2>
-                        <ul class="elegant-interest-list">
-                            @foreach ($data['hobbies'] as $hobby)
-                                <li>{{ $hobby }}</li>
-                            @endforeach
-                        </ul>
-                    </section>
-                @endif
-            </aside>
         </div>
     </div>
 </body>

--- a/resources/views/templates/minimal.blade.php
+++ b/resources/views/templates/minimal.blade.php
@@ -21,139 +21,142 @@
     @endphp
 
     <div class="minimal-wrapper">
-        <aside class="minimal-sidebar">
-            <div class="minimal-identity">
+        <header class="minimal-header">
+            <div class="minimal-header__inner">
                 @if ($profileImage)
-                    <div class="minimal-avatar">
+                    <div class="minimal-header__avatar">
                         <img src="{{ $profileImage }}" alt="{{ $data['name'] ?? __('Profile photo') }}">
                     </div>
                 @elseif ($initials)
-                    <div class="minimal-avatar minimal-avatar--initials">{{ $initials }}</div>
+                    <div class="minimal-header__avatar minimal-header__avatar--initials">{{ $initials }}</div>
                 @endif
-                <div class="minimal-identity__text">
+                <div class="minimal-header__identity">
                     <h1>{{ $data['name'] ?? __('Your Name') }}</h1>
                     @if ($data['headline'])
-                        <p class="minimal-headline">{{ $data['headline'] }}</p>
+                        <p class="minimal-header__headline">{{ $data['headline'] }}</p>
+                    @endif
+                    @if (($data['location'] ?? null) || ($data['phone'] ?? null))
+                        <div class="minimal-header__meta">
+                            @if ($data['location'] ?? null)
+                                <span>{{ $data['location'] }}</span>
+                            @endif
+                            @if ($data['phone'] ?? null)
+                                <span>{{ $data['phone'] }}</span>
+                            @endif
+                        </div>
                     @endif
                 </div>
             </div>
+        </header>
 
-            @if (!empty($data['contacts']))
-                <dl class="minimal-contact">
-                    @foreach ($data['contacts'] as $contact)
-                        <div>
-                            <dt>{{ __('Contact') }}</dt>
-                            <dd>{{ $contact }}</dd>
+        <div class="minimal-layout">
+            <aside class="minimal-column minimal-column--left">
+                @if (!empty($data['skills']))
+                    <section class="minimal-sidebar-section">
+                        <h2>{{ __('Strengths') }}</h2>
+                        <ul>
+                            @foreach ($data['skills'] as $skill)
+                                <li>{{ $skill }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+
+                @if (!empty($data['languages']))
+                    <section class="minimal-sidebar-section">
+                        <h2>{{ __('Languages') }}</h2>
+                        <ul>
+                            @foreach ($data['languages'] as $language)
+                                <li>
+                                    <span>{{ $language['name'] }}</span>
+                                    @if (!empty($language['level']))
+                                        <span class="minimal-badge">{{ ucfirst($language['level']) }}</span>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+
+                @if (!empty($data['hobbies']))
+                    <section class="minimal-sidebar-section">
+                        <h2>{{ __('Interests & Hobbies') }}</h2>
+                        <ul class="minimal-pill-list">
+                            @foreach ($data['hobbies'] as $hobby)
+                                <li>{{ $hobby }}</li>
+                            @endforeach
+                        </ul>
+                    </section>
+                @endif
+            </aside>
+
+            <main class="minimal-column minimal-column--right">
+                @if ($summaryParagraphs->isNotEmpty())
+                    <section class="minimal-section minimal-section--summary">
+                        <h2>{{ __('Overview') }}</h2>
+                        <div class="minimal-section__body">
+                            @foreach ($summaryParagraphs as $paragraph)
+                                <p>{{ $paragraph }}</p>
+                            @endforeach
                         </div>
-                    @endforeach
-                </dl>
-            @endif
+                    </section>
+                @endif
 
-            @if (!empty($data['skills']))
-                <section class="minimal-sidebar-section">
-                    <h2>{{ __('Strengths') }}</h2>
-                    <ul>
-                        @foreach ($data['skills'] as $skill)
-                            <li>{{ $skill }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
+                @if (!empty($data['experiences']))
+                    <section class="minimal-section">
+                        <header class="minimal-section__header">
+                            <h2>{{ __('Experience') }}</h2>
+                            <p>{{ __('Roles, results and responsibilities in reverse chronology.') }}</p>
+                        </header>
+                        <div class="minimal-timeline">
+                            @foreach ($data['experiences'] as $experience)
+                                <article class="minimal-timeline__item">
+                                    <div class="minimal-timeline__meta">
+                                        @if ($experience['period'])
+                                            <span class="minimal-timeline__period">{{ $experience['period'] }}</span>
+                                        @endif
+                                        <span class="minimal-timeline__company">{{ collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter()->implode(' · ') }}</span>
+                                    </div>
+                                    <div class="minimal-timeline__content">
+                                        @if ($experience['role'])
+                                            <h3>{{ $experience['role'] }}</h3>
+                                        @endif
+                                        @if ($experience['summary'])
+                                            <p>{{ $experience['summary'] }}</p>
+                                        @endif
+                                    </div>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
 
-            @if (!empty($data['languages']))
-                <section class="minimal-sidebar-section">
-                    <h2>{{ __('Languages') }}</h2>
-                    <ul>
-                        @foreach ($data['languages'] as $language)
-                            <li>
-                                <span>{{ $language['name'] }}</span>
-                                @if (!empty($language['level']))
-                                    <span class="minimal-badge">{{ ucfirst($language['level']) }}</span>
-                                @endif
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-
-            @if (!empty($data['hobbies']))
-                <section class="minimal-sidebar-section">
-                    <h2>{{ __('Interests') }}</h2>
-                    <ul class="minimal-pill-list">
-                        @foreach ($data['hobbies'] as $hobby)
-                            <li>{{ $hobby }}</li>
-                        @endforeach
-                    </ul>
-                </section>
-            @endif
-        </aside>
-
-        <main class="minimal-content">
-            @if ($summaryParagraphs->isNotEmpty())
-                <section class="minimal-section minimal-section--summary">
-                    <h2>{{ __('Overview') }}</h2>
-                    <div class="minimal-section__body">
-                        @foreach ($summaryParagraphs as $paragraph)
-                            <p>{{ $paragraph }}</p>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
-
-            @if (!empty($data['experiences']))
-                <section class="minimal-section">
-                    <header class="minimal-section__header">
-                        <h2>{{ __('Experience') }}</h2>
-                        <p>{{ __('Roles, results and responsibilities in reverse chronology.') }}</p>
-                    </header>
-                    <div class="minimal-timeline">
-                        @foreach ($data['experiences'] as $experience)
-                            <article class="minimal-timeline__item">
-                                <div class="minimal-timeline__meta">
-                                    @if ($experience['period'])
-                                        <span class="minimal-timeline__period">{{ $experience['period'] }}</span>
+                @if (!empty($data['education']))
+                    <section class="minimal-section">
+                        <header class="minimal-section__header">
+                            <h2>{{ __('Education') }}</h2>
+                            <p>{{ __('Programmes and academic achievements.') }}</p>
+                        </header>
+                        <div class="minimal-education">
+                            @foreach ($data['education'] as $education)
+                                <article>
+                                    <h3>{{ $education['institution'] }}</h3>
+                                    <div class="minimal-education__details">
+                                        <span>{{ collect([$education['degree'] ?? null, $education['field'] ?? null])->filter()->implode(' · ') }}</span>
+                                        @if ($education['period'])
+                                            <span>{{ $education['period'] }}</span>
+                                        @endif
+                                    </div>
+                                    @if ($education['location'])
+                                        <p>{{ $education['location'] }}</p>
                                     @endif
-                                    <span class="minimal-timeline__company">{{ collect([$experience['company'] ?? null, $experience['location'] ?? null])->filter()->implode(' · ') }}</span>
-                                </div>
-                                <div class="minimal-timeline__content">
-                                    @if ($experience['role'])
-                                        <h3>{{ $experience['role'] }}</h3>
-                                    @endif
-                                    @if ($experience['summary'])
-                                        <p>{{ $experience['summary'] }}</p>
-                                    @endif
-                                </div>
-                            </article>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
-
-            @if (!empty($data['education']))
-                <section class="minimal-section">
-                    <header class="minimal-section__header">
-                        <h2>{{ __('Education') }}</h2>
-                        <p>{{ __('Programmes and academic achievements.') }}</p>
-                    </header>
-                    <div class="minimal-education">
-                        @foreach ($data['education'] as $education)
-                            <article>
-                                <h3>{{ $education['institution'] }}</h3>
-                                <div class="minimal-education__details">
-                                    <span>{{ collect([$education['degree'] ?? null, $education['field'] ?? null])->filter()->implode(' · ') }}</span>
-                                    @if ($education['period'])
-                                        <span>{{ $education['period'] }}</span>
-                                    @endif
-                                </div>
-                                @if ($education['location'])
-                                    <p>{{ $education['location'] }}</p>
-                                @endif
-                            </article>
-                        @endforeach
-                    </div>
-                </section>
-            @endif
-        </main>
+                                </article>
+                            @endforeach
+                        </div>
+                    </section>
+                @endif
+            </main>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- center the hero identity in the minimal, elegant, and corporate templates with location and phone details beneath the name
- restructure each template so interests, hobbies, and languages render in the left column while education and experience remain on the right
- refresh the corresponding CSS to support the new header presentation and two-column layout

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2545ded088332ae5d3a5cce4a2b65