### PR TITLE
Adjust template previews for better visibility

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -393,6 +393,14 @@
         @apply inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-blue-500 hover:text-blue-600;
     }
 
+    .createit-template-preview__inner {
+        transform: scale(0.9);
+        transform-origin: top center;
+        height: 111%;
+        width: 111%;
+        margin: 0 auto;
+    }
+
     .createit-modal {
         @apply m-0 w-full max-w-5xl overflow-hidden rounded-[32px] border border-slate-200 bg-white/95 p-0 shadow-2xl backdrop:bg-slate-900/70;
     }

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -386,19 +386,21 @@
                         <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Template') }}</p>
                         <h2 class="text-lg font-semibold text-slate-900">{{ $templateInfo['title'] }}</h2>
                         <p class="text-sm text-slate-600">{{ $templateInfo['description'] }}</p>
-                        <div class="relative mt-4 h-52 overflow-hidden rounded-2xl bg-gradient-to-br {{ $templateInfo['preview'] }} shadow-inner shadow-slate-400/20">
-                            @if (!empty($templateInfo['partial']) && view()->exists($templateInfo['partial']))
-                                @include($templateInfo['partial'])
-                            @else
-                                <div class="p-4">
-                                    <div class="h-2 w-24 rounded-full bg-white/70"></div>
-                                    <div class="mt-4 space-y-2">
-                                        <div class="h-2 w-28 rounded-full bg-white/60"></div>
-                                        <div class="h-2 w-32 rounded-full bg-white/40"></div>
-                                        <div class="h-16 rounded-2xl border border-white/50 bg-white/30"></div>
+                        <div class="createit-template-preview relative mt-4 h-52 overflow-hidden rounded-2xl bg-gradient-to-br {{ $templateInfo['preview'] }} shadow-inner shadow-slate-400/20">
+                            <div class="createit-template-preview__inner">
+                                @if (!empty($templateInfo['partial']) && view()->exists($templateInfo['partial']))
+                                    @include($templateInfo['partial'])
+                                @else
+                                    <div class="p-4">
+                                        <div class="h-2 w-24 rounded-full bg-white/70"></div>
+                                        <div class="mt-4 space-y-2">
+                                            <div class="h-2 w-28 rounded-full bg-white/60"></div>
+                                            <div class="h-2 w-32 rounded-full bg-white/40"></div>
+                                            <div class="h-16 rounded-2xl border border-white/50 bg-white/30"></div>
+                                        </div>
                                     </div>
-                                </div>
-                            @endif
+                                @endif
+                            </div>
                         </div>
                         <div class="flex flex-col gap-3 pt-2">
                             <a href="{{ route('cv.download', array_filter(['template' => $templateKey, 'cv' => request('cv')])) }}" class="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-slate-400/40 transition hover:-translate-y-0.5 hover:bg-black">

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -81,7 +81,7 @@
                 <div class="group createit-template-card">
                     <div class="createit-template-card__preview">
                         <iframe
-                            src="{{ route('cv.template-preview', $template) }}#toolbar=0&navpanes=0&scrollbar=0"
+                            src="{{ route('cv.template-preview', $template) }}#toolbar=0&navpanes=0&scrollbar=0&zoom=page-fit"
                             title="{{ __('Preview of the :template template', ['template' => $meta['title']]) }}"
                             class="createit-template-card__preview-frame"
                             loading="lazy"


### PR DESCRIPTION
## Summary
- add scaling wrapper around template preview components so thumbnails are slightly zoomed out
- tweak template preview iframe to request a page-fit zoom level for embedded PDFs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3562d6f24833281a4a8d1080a67b8