### PR TITLE
Fix preview edit link to open existing CV

### DIFF
--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -407,9 +407,18 @@
                                 {{ __('Download PDF') }}
                                 <span aria-hidden="true">&darr;</span>
                             </a>
-                            <a href="{{ route('cv.create', ['template' => $templateKey]) }}" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:bg-slate-50">
-                                {{ __('Edit details') }}
-                            </a>
+                            @php
+                                $cvId = $cvData['id'] ?? null;
+                            @endphp
+                            @if ($cvId)
+                                <a href="{{ route('cv.edit', ['cv' => $cvId]) }}" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:bg-slate-50">
+                                    {{ __('Edit details') }}
+                                </a>
+                            @else
+                                <a href="{{ route('cv.create', ['template' => $templateKey]) }}" class="inline-flex items-center justify-center gap-2 rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:bg-slate-50">
+                                    {{ __('Edit details') }}
+                                </a>
+                            @endif
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- update the CV preview "Edit details" button to open the edit form when a saved CV is loaded
- fall back to the create form only when no saved CV ID is available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e362b097cc8332aa3f25a6366611b1