### PR TITLE
Show live PDF preview on CV preview page

### DIFF
--- a/app/Http/Controllers/CvController.php
+++ b/app/Http/Controllers/CvController.php
@@ -184,7 +184,7 @@ class CvController extends Controller
         $cvData = $this->resolveCvData($request);
         $template = $cvData['template'] ?? 'classic';
 
-        return $this->renderPdf($cvData, $template, $this->filenameForCv($cvData));
+        return $this->renderPdf($cvData, $template, $this->filenameForCv($cvData), false);
     }
 
     public function getCities(Request $request)

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -75,6 +75,12 @@
                     'partial' => null,
                 ];
 
+                $pdfPreviewParams = array_filter([
+                    'template' => $templateKey,
+                    'cv' => $cvData['id'] ?? request()->query('cv'),
+                ], fn ($value) => !is_null($value));
+                $pdfPreviewUrl = route('cv.pdf', $pdfPreviewParams);
+
                 $fullName = trim(($cvData['first_name'] ?? '') . ' ' . ($cvData['last_name'] ?? ''));
                 $email = $cvData['email'] ?? null;
                 $phone = $cvData['phone'] ?? null;
@@ -245,6 +251,20 @@
 
             <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
                 <section class="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm space-y-8">
+                    <div>
+                        <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Live PDF preview') }}</p>
+                        <div class="mt-4 overflow-hidden rounded-3xl border border-slate-200 bg-slate-100 shadow-inner shadow-slate-400/30">
+                            <iframe
+                                src="{{ $pdfPreviewUrl }}#toolbar=0&navpanes=0&scrollbar=0&zoom=page-fit"
+                                title="{{ __('Live preview of your CV PDF') }}"
+                                class="h-[70vh] w-full"
+                                loading="lazy"
+                            >
+                                {{ __('PDF preview of your CV.') }}
+                            </iframe>
+                        </div>
+                        <p class="mt-2 text-xs text-slate-500">{{ __('This preview shows the exact PDF layout for your selected template.') }}</p>
+                    </div>
                     <div>
                         <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Overview') }}</p>
                         <div class="mt-4 flex flex-col gap-6 sm:flex-row sm:items-start">

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware('auth')->group(function () {
         Route::patch('/{cv}/template','updateTemplate')->name('cv.update-template');
         Route::delete('/{cv}','destroy')->name('cv.destroy');
         Route::get('/preview','preview')->name('cv.preview');
+        Route::get('/pdf','pdf')->name('cv.pdf');
         Route::get('/guide','guide')->name('cv.guide');
 
         // API endpoints routed to controller methods


### PR DESCRIPTION
## Summary
- embed the CV PDF preview in the preview page so users see the final layout
- add a streaming route for inline CV PDFs and adjust the controller to stream instead of download

## Testing
- ./vendor/bin/phpunit *(fails: file not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e370842fec833298bc9ae88f39c425