### PR TITLE
Show live CV preview in template panel

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -394,11 +394,11 @@
     }
 
     .createit-template-preview__inner {
-        transform: scale(0.9);
-        transform-origin: top center;
-        height: 111%;
-        width: 111%;
-        margin: 0 auto;
+        @apply h-full w-full overflow-hidden;
+    }
+
+    .createit-template-preview__frame {
+        @apply h-full w-full border-0;
     }
 
     .createit-modal {

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -410,18 +410,15 @@
                         <p class="text-sm text-slate-600">{{ $templateInfo['description'] }}</p>
                         <div class="createit-template-preview relative mt-4 h-52 overflow-hidden rounded-2xl bg-gradient-to-br {{ $templateInfo['preview'] }} shadow-inner shadow-slate-400/20">
                             <div class="createit-template-preview__inner">
-                                @if (!empty($templateInfo['partial']) && view()->exists($templateInfo['partial']))
-                                    @include($templateInfo['partial'])
-                                @else
-                                    <div class="p-4">
-                                        <div class="h-2 w-24 rounded-full bg-white/70"></div>
-                                        <div class="mt-4 space-y-2">
-                                            <div class="h-2 w-28 rounded-full bg-white/60"></div>
-                                            <div class="h-2 w-32 rounded-full bg-white/40"></div>
-                                            <div class="h-16 rounded-2xl border border-white/50 bg-white/30"></div>
-                                        </div>
-                                    </div>
-                                @endif
+                                <iframe
+                                    src="{{ $pdfPreviewUrl }}#toolbar=0&navpanes=0&scrollbar=0&zoom=page-fit"
+                                    title="{{ __('Live preview of your CV PDF') }}"
+                                    class="createit-template-preview__frame"
+                                    scrolling="no"
+                                    loading="lazy"
+                                >
+                                    {{ __('PDF preview of your CV.') }}
+                                </iframe>
                             </div>
                         </div>
                         <div class="flex flex-col gap-3 pt-2">


### PR DESCRIPTION
## Summary
- replace the static template preview with an embedded iframe that mirrors the live CV PDF preview
- adjust the template preview styles to let the iframe fill the available space

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e373e00ce08332bf368f50a1b10d95