### PR TITLE
Remove outer borders from PDF resume templates

### DIFF
--- a/resources/views/cv/pdf/templates/classic.blade.php
+++ b/resources/views/cv/pdf/templates/classic.blade.php
@@ -16,7 +16,6 @@
 
     body.template-classic .classic-page {
         background-color: #ffffff;
-        border: 2px solid #d9c7a3;
         border-radius: 18px;
         padding: 26px 30px 30px;
         box-shadow: none;

--- a/resources/views/cv/pdf/templates/corporate.blade.php
+++ b/resources/views/cv/pdf/templates/corporate.blade.php
@@ -13,7 +13,6 @@
 
     body.template-corporate .corporate-page {
         background-color: #ffffff;
-        border: 1px solid #cbd5e1;
         border-radius: 20px;
         overflow: hidden;
     }

--- a/resources/views/cv/pdf/templates/creative.blade.php
+++ b/resources/views/cv/pdf/templates/creative.blade.php
@@ -14,7 +14,6 @@
 
     body.template-creative .creative-page {
         background-color: #ffffff;
-        border: 2px solid #fbd1e9;
         border-radius: 24px;
         padding: 0;
         overflow: hidden;

--- a/resources/views/cv/pdf/templates/darkmode.blade.php
+++ b/resources/views/cv/pdf/templates/darkmode.blade.php
@@ -14,7 +14,6 @@
 
     body.template-darkmode .dark-page {
         background-color: #1f2937;
-        border: 1px solid #374151;
         border-radius: 20px;
         overflow: hidden;
     }

--- a/resources/views/cv/pdf/templates/elegant.blade.php
+++ b/resources/views/cv/pdf/templates/elegant.blade.php
@@ -13,7 +13,6 @@
 
     body.template-elegant .elegant-page {
         background-color: #ffffff;
-        border: 1px solid #dccdf2;
         border-radius: 24px;
         padding: 30px 34px;
     }

--- a/resources/views/cv/pdf/templates/futuristic.blade.php
+++ b/resources/views/cv/pdf/templates/futuristic.blade.php
@@ -14,7 +14,6 @@
 
     body.template-futuristic .futuristic-page {
         background-color: #111827;
-        border: 1px solid #1f2937;
         border-radius: 24px;
         overflow: hidden;
     }

--- a/resources/views/cv/pdf/templates/gradient.blade.php
+++ b/resources/views/cv/pdf/templates/gradient.blade.php
@@ -14,7 +14,6 @@
 
     body.template-gradient .gradient-page {
         background-color: #ffffff;
-        border: 2px solid #cdeafe;
         border-radius: 22px;
         overflow: hidden;
     }

--- a/resources/views/cv/pdf/templates/minimal.blade.php
+++ b/resources/views/cv/pdf/templates/minimal.blade.php
@@ -13,7 +13,6 @@
 
     body.template-minimal .minimal-page {
         background-color: #ffffff;
-        border: 1px solid #d6deeb;
         border-radius: 18px;
         padding: 28px 32px;
     }

--- a/resources/views/cv/pdf/templates/modern.blade.php
+++ b/resources/views/cv/pdf/templates/modern.blade.php
@@ -13,7 +13,6 @@
 
     body.template-modern .modern-page {
         background-color: #ffffff;
-        border: 1px solid #cbd5f5;
         border-radius: 20px;
         padding: 0;
         overflow: hidden;


### PR DESCRIPTION
## Summary
- remove the page container border from every PDF resume template so the exported CV has clean edges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3752e6f448332aad726512a24f4c1