### PR TITLE
Allow editing CV forms to jump between steps

### DIFF
--- a/resources/js/cv-form.js
+++ b/resources/js/cv-form.js
@@ -11,8 +11,9 @@ const initCvForm = () => {
     const prevButton = document.getElementById('prevStep');
     const submitButton = document.getElementById('submitStep');
     const totalSteps = stepPanels.length;
+    const isEditing = form.dataset.isEditing === 'true';
     let currentStep = 1;
-    let maxStepVisited = 1;
+    let maxStepVisited = isEditing ? totalSteps : 1;
     const stepErrors = new Map();
 
     const photoInput = form.querySelector('input[name="profile_image"]');

--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -316,7 +316,7 @@
                     </div>
                 </div>
 
-                <form method="POST" action="{{ $formAction }}" id="cvForm" class="space-y-10" enctype="multipart/form-data" data-cities-endpoint="{{ route('cv.cities') }}">
+                <form method="POST" action="{{ $formAction }}" id="cvForm" class="space-y-10" enctype="multipart/form-data" data-cities-endpoint="{{ route('cv.cities') }}" data-is-editing="{{ $isEditing ? 'true' : 'false' }}">
                     @csrf
                     @if ($formMethod !== 'POST')
                         @method($formMethod)


### PR DESCRIPTION
## Summary
- allow step navigation buttons when editing an existing CV
- expose the editing state to the client script so step navigation unlocks immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4df3307688332b89271bc8687e9b7