### PR TITLE
Improve previous step scroll behavior

### DIFF
--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -296,7 +296,7 @@
                 </div>
             @endif
 
-            <div class="bg-white/95 backdrop-blur-xl shadow-xl rounded-[32px] p-6 sm:p-10 md:p-12">
+            <div class="bg-white/95 backdrop-blur-xl shadow-xl rounded-[32px] p-6 sm:p-10 md:p-12" data-scroll-anchor="cv-form-container">
                 <div class="mb-12">
                     <div class="flex flex-col gap-6 md:flex-row md:items-center md:gap-4">
                         @foreach ($stepItems as $index => $step)


### PR DESCRIPTION
## Summary
- add a scroll anchor to the CV form container to support targeted scrolling
- replace the previous-step jump with a smooth scroll that stops near the form container top
- implement a reusable scroll animation helper for consistent timing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4e2afdb448332b9cc5c87f6ca5624