### PR TITLE
Ensure CV form next steps scroll to form container

### DIFF
--- a/resources/js/cv-form.js
+++ b/resources/js/cv-form.js
@@ -69,14 +69,6 @@ const initCvForm = () => {
         window.requestAnimationFrame(step);
     };
 
-    const scrollToTop = () => {
-        if (typeof window === 'undefined') {
-            return;
-        }
-
-        animateScrollTo(0, { duration: 500 });
-    };
-
     const scrollToFormContainer = () => {
         if (typeof window === 'undefined') {
             return;
@@ -375,7 +367,7 @@ const initCvForm = () => {
         currentStep += 1;
         maxStepVisited = Math.max(maxStepVisited, currentStep);
         updateStepVisuals();
-        scrollToTop();
+        scrollToFormContainer();
     });
 
     prevButton?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- update the CV form step navigation to scroll to the main form container instead of the window top when moving forward

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e512dfe48332adcb4eec7f723d1b