### PR TITLE
Add profile photo management to profile settings

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ProfileUpdateRequest;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\View\View;
 
 class ProfileController extends Controller
@@ -22,15 +24,51 @@ class ProfileController extends Controller
     
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        $user = $request->user();
+        $validated = $request->validated();
 
-        if ($request->user()->isDirty('email')) {
-            $request->user()->email_verified_at = null;
+        $user->fill(Arr::except($validated, ['profile_photo', 'remove_profile_photo']));
+
+        $oldAvatar = $user->getOriginal('avatar_url');
+
+        if ($request->hasFile('profile_photo')) {
+            $newPath = $request->file('profile_photo')->store('profile-photos', 'public');
+
+            if ($oldAvatar !== $newPath) {
+                $this->deleteStoredProfilePhoto($oldAvatar);
+            }
+
+            $user->avatar_url = $newPath;
+        } elseif ($request->boolean('remove_profile_photo')) {
+            $this->deleteStoredProfilePhoto($oldAvatar);
+            $user->avatar_url = null;
         }
 
-        $request->user()->save();
+        if ($user->isDirty('email')) {
+            $user->email_verified_at = null;
+        }
+
+        $user->save();
 
         return Redirect::route('profile.edit')->with('status', 'profile-updated');
+    }
+
+
+    protected function deleteStoredProfilePhoto(?string $path): void
+    {
+        if (! is_string($path) || trim($path) === '') {
+            return;
+        }
+
+        if (filter_var($path, FILTER_VALIDATE_URL)) {
+            return;
+        }
+
+        try {
+            Storage::disk('public')->delete($path);
+        } catch (\Throwable $e) {
+            // Silently ignore cleanup failures.
+        }
     }
 
     

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -25,6 +25,8 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'profile_photo' => ['nullable', 'image', 'max:2048'],
+            'remove_profile_photo' => ['nullable', 'boolean'],
         ];
     }
 }

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,3 +1,14 @@
+@php
+    $storedAvatar = $user->avatar_url;
+    $displayAvatar = null;
+
+    if (is_string($storedAvatar) && trim($storedAvatar) !== '') {
+        $displayAvatar = filter_var($storedAvatar, FILTER_VALIDATE_URL)
+            ? $storedAvatar
+            : \Illuminate\Support\Facades\Storage::disk('public')->url($storedAvatar);
+    }
+@endphp
+
 <section class="rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-xl shadow-slate-900/5 backdrop-blur">
     <header class="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-center sm:justify-between">
         <div class="flex items-start gap-4">
@@ -24,7 +35,7 @@
         @csrf
     </form>
 
-    <form method="post" action="{{ route('profile.update') }}" class="mt-8 grid gap-6 sm:grid-cols-2">
+    <form method="post" action="{{ route('profile.update') }}" class="mt-8 grid gap-6 sm:grid-cols-2" enctype="multipart/form-data">
         @csrf
         @method('patch')
 
@@ -59,6 +70,45 @@
                     @endif
                 </div>
             @endif
+        </div>
+
+        <div class="sm:col-span-2">
+            <x-input-label for="profile_photo" :value="__('Profile photo')" class="text-sm font-semibold text-slate-700" />
+
+            <div class="mt-3 flex flex-wrap items-center gap-5">
+                <div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-slate-200 shadow-inner">
+                    @if ($displayAvatar)
+                        <img src="{{ $displayAvatar }}" alt="{{ __('Profile photo preview') }}" class="h-full w-full object-cover">
+                    @else
+                        <span class="text-lg font-semibold text-slate-500">
+                            {{ \Illuminate\Support\Str::of($user->name)->trim()->take(2)->upper() ?: __('You') }}
+                        </span>
+                    @endif
+                </div>
+
+                <div class="flex-1 space-y-3">
+                    <input
+                        id="profile_photo"
+                        name="profile_photo"
+                        type="file"
+                        accept="image/*"
+                        class="block w-full text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-600 hover:file:bg-indigo-100"
+                    >
+
+                    <p class="text-xs text-slate-500">
+                        {{ __('Upload a square image (max 2 MB) to personalize your profile and CV templates.') }}
+                    </p>
+
+                    @if ($displayAvatar)
+                        <label class="inline-flex items-center gap-2 text-sm text-slate-600">
+                            <input type="checkbox" name="remove_profile_photo" value="1" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                            <span>{{ __('Remove current photo') }}</span>
+                        </label>
+                    @endif
+                </div>
+            </div>
+
+            <x-input-error class="mt-2" :messages="$errors->get('profile_photo')" />
         </div>
 
         <div class="flex flex-wrap items-center gap-3 sm:col-span-2">

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 
 test('profile page is displayed', function () {
     $user = User::factory()->create();
@@ -48,6 +50,56 @@ test('email verification status is unchanged when the email address is unchanged
         ->assertRedirect('/profile');
 
     $this->assertNotNull($user->refresh()->email_verified_at);
+});
+
+test('profile photo can be uploaded', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->patch('/profile', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'profile_photo' => UploadedFile::fake()->image('avatar.jpg', 400, 400),
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/profile');
+
+    $user->refresh();
+
+    $this->assertNotNull($user->avatar_url);
+    Storage::disk('public')->assertExists($user->avatar_url);
+});
+
+test('stored profile photo can be removed', function () {
+    Storage::fake('public');
+
+    $user = User::factory()->create([
+        'avatar_url' => 'profile-photos/original.jpg',
+    ]);
+
+    Storage::disk('public')->put($user->avatar_url, 'avatar');
+
+    $response = $this
+        ->actingAs($user)
+        ->patch('/profile', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'remove_profile_photo' => '1',
+        ]);
+
+    $response
+        ->assertSessionHasNoErrors()
+        ->assertRedirect('/profile');
+
+    $user->refresh();
+
+    $this->assertNull($user->avatar_url);
+    Storage::disk('public')->assertMissing('profile-photos/original.jpg');
 });
 
 test('user can delete their account', function () {


### PR DESCRIPTION
## Summary
- allow uploading and removing profile photos in the profile settings form
- persist uploaded photos on the public disk while cleaning up replaced files safely
- expose the new controls in the UI and cover the workflow with feature tests

## Testing
- php artisan test *(fails: missing `vendor/autoload.php` because Composer install is blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eaa037e88332b253dec43f7943ee