### PR TITLE
Fix profile photo preview not updating

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,7 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
+import './profile-photo';
 
 window.Alpine = Alpine;
 

--- a/resources/js/profile-photo.js
+++ b/resources/js/profile-photo.js
@@ -1,0 +1,106 @@
+const initProfilePhotoPreview = () => {
+    const input = document.querySelector('[data-profile-photo-input]');
+    if (!input) {
+        return;
+    }
+
+    const previewContainer = document.querySelector('[data-profile-photo-preview]');
+    const previewImage = previewContainer?.querySelector('[data-profile-photo-preview-image]') ?? null;
+    const placeholder = previewContainer?.querySelector('[data-profile-photo-placeholder]') ?? null;
+    const removeCheckbox = document.querySelector('[data-profile-photo-remove]');
+    const initialPreviewSrc = previewImage?.getAttribute('src')?.trim() || null;
+    let currentObjectUrl = null;
+
+    const revokeCurrentObjectUrl = () => {
+        if (currentObjectUrl) {
+            URL.revokeObjectURL(currentObjectUrl);
+            currentObjectUrl = null;
+        }
+    };
+
+    const showPlaceholder = () => {
+        revokeCurrentObjectUrl();
+
+        if (previewImage) {
+            previewImage.classList.add('hidden');
+            previewImage.removeAttribute('src');
+        }
+
+        if (placeholder) {
+            placeholder.classList.remove('hidden');
+        }
+    };
+
+    const showImage = (url) => {
+        if (!url) {
+            showPlaceholder();
+            return;
+        }
+
+        if (previewImage) {
+            previewImage.src = url;
+            previewImage.classList.remove('hidden');
+        }
+
+        if (placeholder) {
+            placeholder.classList.add('hidden');
+        }
+    };
+
+    const resetPreview = () => {
+        if (initialPreviewSrc) {
+            showImage(initialPreviewSrc);
+        } else {
+            showPlaceholder();
+        }
+    };
+
+    const handleFileChange = () => {
+        const [file] = input.files || [];
+
+        if (!file) {
+            if (removeCheckbox?.checked) {
+                showPlaceholder();
+            } else {
+                resetPreview();
+            }
+            return;
+        }
+
+        const objectUrl = URL.createObjectURL(file);
+        revokeCurrentObjectUrl();
+        currentObjectUrl = objectUrl;
+
+        if (removeCheckbox) {
+            removeCheckbox.checked = false;
+        }
+
+        showImage(objectUrl);
+    };
+
+    const handleRemoveChange = () => {
+        if (!removeCheckbox) {
+            return;
+        }
+
+        if (removeCheckbox.checked) {
+            if (input.value) {
+                input.value = '';
+            }
+            showPlaceholder();
+        } else {
+            resetPreview();
+        }
+    };
+
+    input.addEventListener('change', handleFileChange);
+    removeCheckbox?.addEventListener('change', handleRemoveChange);
+
+    window.addEventListener('beforeunload', revokeCurrentObjectUrl);
+};
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initProfilePhotoPreview);
+} else {
+    initProfilePhotoPreview();
+}

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -76,14 +76,24 @@
             <x-input-label for="profile_photo" :value="__('Profile photo')" class="text-sm font-semibold text-slate-700" />
 
             <div class="mt-3 flex flex-wrap items-center gap-5">
-                <div class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-slate-200 shadow-inner">
-                    @if ($displayAvatar)
-                        <img src="{{ $displayAvatar }}" alt="{{ __('Profile photo preview') }}" class="h-full w-full object-cover">
-                    @else
-                        <span class="text-lg font-semibold text-slate-500">
-                            {{ \Illuminate\Support\Str::of($user->name)->trim()->take(2)->upper() ?: __('You') }}
-                        </span>
-                    @endif
+                @php($initials = \Illuminate\Support\Str::of($user->name)->trim()->take(2)->upper() ?: __('You'))
+
+                <div
+                    class="flex h-20 w-20 items-center justify-center overflow-hidden rounded-2xl bg-slate-200 shadow-inner"
+                    data-profile-photo-preview
+                >
+                    <img
+                        src="{{ $displayAvatar }}"
+                        alt="{{ __('Profile photo preview') }}"
+                        class="h-full w-full object-cover {{ $displayAvatar ? '' : 'hidden' }}"
+                        data-profile-photo-preview-image
+                    >
+                    <span
+                        class="text-lg font-semibold text-slate-500 {{ $displayAvatar ? 'hidden' : '' }}"
+                        data-profile-photo-placeholder
+                    >
+                        {{ $initials }}
+                    </span>
                 </div>
 
                 <div class="flex-1 space-y-3">
@@ -92,6 +102,7 @@
                         name="profile_photo"
                         type="file"
                         accept="image/*"
+                        data-profile-photo-input
                         class="block w-full text-sm text-slate-600 file:mr-4 file:rounded-full file:border-0 file:bg-indigo-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-indigo-600 hover:file:bg-indigo-100"
                     >
 
@@ -101,7 +112,13 @@
 
                     @if ($displayAvatar)
                         <label class="inline-flex items-center gap-2 text-sm text-slate-600">
-                            <input type="checkbox" name="remove_profile_photo" value="1" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500">
+                            <input
+                                type="checkbox"
+                                name="remove_profile_photo"
+                                value="1"
+                                class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                                data-profile-photo-remove
+                            >
                             <span>{{ __('Remove current photo') }}</span>
                         </label>
                     @endif


### PR DESCRIPTION
## Summary
- add data attributes and markup to support toggling the profile photo preview and fallback initials
- introduce a dedicated script to update the profile preview when selecting a new image or removing the current one
- import the new script in the shared app bundle so it runs on the profile page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ec4da9fc8332a6747a7856e00233