### PR TITLE
Fix account avatar preview when stored locally

### DIFF
--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -254,6 +254,25 @@
             $accountAvatarUrl = null;
         }
 
+        if ($accountAvatarUrl) {
+            if (!filter_var($accountAvatarUrl, FILTER_VALIDATE_URL)) {
+                $storagePath = preg_replace('#^/?storage/#', '', $accountAvatarUrl);
+                $storagePath = ltrim((string) $storagePath, '/');
+
+                try {
+                    if ($storagePath !== '' && \Illuminate\Support\Facades\Storage::disk('public')->exists($storagePath)) {
+                        $accountAvatarUrl = \Illuminate\Support\Facades\Storage::disk('public')->url($storagePath);
+                    } elseif (\Illuminate\Support\Facades\Storage::disk('public')->exists(ltrim($accountAvatarUrl, '/'))) {
+                        $accountAvatarUrl = \Illuminate\Support\Facades\Storage::disk('public')->url(ltrim($accountAvatarUrl, '/'));
+                    } else {
+                        $accountAvatarUrl = null;
+                    }
+                } catch (\Throwable $e) {
+                    $accountAvatarUrl = null;
+                }
+            }
+        }
+
         $hasAccountAvatar = $accountAvatarUrl !== null;
         $matchesAccountAvatar = $hasAccountAvatar && $storedProfileImageUrl && $storedProfileImageUrl === $accountAvatarUrl;
         $initialUploadPhotoUrl = $matchesAccountAvatar ? null : $storedProfileImageUrl;

--- a/tests/Feature/CvManagementTest.php
+++ b/tests/Feature/CvManagementTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Cv;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class CvManagementTest extends TestCase
@@ -145,5 +146,22 @@ class CvManagementTest extends TestCase
         $this->actingAs($user)
             ->delete(route('cv.destroy', $otherCv))
             ->assertForbidden();
+    }
+
+    public function test_create_form_shows_resolved_avatar_url_for_account_photo(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create([
+            'avatar_url' => 'profile-photos/account.jpg',
+        ]);
+
+        Storage::disk('public')->put('profile-photos/account.jpg', 'avatar');
+
+        $response = $this->actingAs($user)->get(route('cv.create'));
+
+        $response->assertOk();
+        $expectedUrl = Storage::disk('public')->url('profile-photos/account.jpg');
+        $response->assertSee('data-avatar-url="' . e($expectedUrl) . '"', false);
     }
 }


### PR DESCRIPTION
## Summary
- normalise account avatar URLs on the CV form so locally stored profile photos render correctly
- add a feature test that exercises the avatar URL resolution on the create CV page

## Testing
- `php artisan test --filter CvManagementTest` *(fails: missing Composer dependencies due to GitHub token requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ed7c52a883328f935ba479d598d8