### PR TITLE
Align classic template page to bottom

### DIFF
--- a/public/templates/css/classic.css
+++ b/public/templates/css/classic.css
@@ -23,11 +23,16 @@ body.classic-template {
     font-size: 13px;
     line-height: 1.7;
     padding: 56px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .classic-template .page {
     max-width: 1020px;
-    margin: 0 auto;
+    margin: auto auto 0;
     background: var(--classic-panel);
     border-radius: 34px;
     box-shadow: 0 48px 120px var(--classic-shadow);
@@ -324,6 +329,8 @@ body.classic-template {
     body.classic-template {
         padding: 0;
         background: transparent;
+        min-height: auto;
+        display: block;
     }
 
     .classic-template .page {


### PR DESCRIPTION
## Summary
- make the classic resume template body a flex container so the page element sits against the bottom of the viewport
- ensure the page container keeps its print-friendly styling while supporting the new layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f98d7b8483329311604a4ced04f4