### PR TITLE
Align resume templates to bottom of canvas

### DIFF
--- a/public/templates/css/classic.css
+++ b/public/templates/css/classic.css
@@ -23,6 +23,11 @@ body.classic-template {
     font-size: 13px;
     line-height: 1.7;
     padding: 56px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .classic-template .page {
@@ -324,6 +329,8 @@ body.classic-template {
     body.classic-template {
         padding: 0;
         background: transparent;
+        min-height: auto;
+        display: block;
     }
 
     .classic-template .page {

--- a/public/templates/css/corporate.css
+++ b/public/templates/css/corporate.css
@@ -21,6 +21,20 @@ body.corporate-template {
     background: var(--corporate-background);
     color: var(--corporate-ink);
     padding: 72px 48px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+@media print {
+    body.corporate-template {
+        padding: 0;
+        background: #ffffff;
+        min-height: auto;
+        display: block;
+    }
 }
 
 .corporate-report {

--- a/public/templates/css/creative.css
+++ b/public/templates/css/creative.css
@@ -22,6 +22,11 @@ body.creative-template {
     font-size: 13px;
     line-height: 1.7;
     padding: 48px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .creative-canvas {
@@ -310,6 +315,8 @@ body.creative-template {
     body.creative-template {
         padding: 0;
         background: #ffffff;
+        min-height: auto;
+        display: block;
     }
 
     .creative-canvas {

--- a/public/templates/css/darkmode.css
+++ b/public/templates/css/darkmode.css
@@ -23,6 +23,11 @@ body.darkmode-template {
     font-size: 13px;
     line-height: 1.7;
     padding: 60px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .darkmode-shell {
@@ -279,6 +284,8 @@ body.darkmode-template {
     body.darkmode-template {
         padding: 0;
         background: #000000;
+        min-height: auto;
+        display: block;
     }
 
     .darkmode-shell {

--- a/public/templates/css/elegant.css
+++ b/public/templates/css/elegant.css
@@ -21,6 +21,11 @@ body.elegant-template {
     font-size: 14px;
     line-height: 1.7;
     padding: 72px 48px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .elegant-document {
@@ -406,5 +411,19 @@ body.elegant-template {
 
     .elegant-card {
         padding: 28px 24px;
+    }
+}
+
+@media print {
+    body.elegant-template {
+        padding: 0;
+        background: #ffffff;
+        min-height: auto;
+        display: block;
+    }
+
+    .elegant-document {
+        border-radius: 0;
+        box-shadow: none;
     }
 }

--- a/public/templates/css/futuristic.css
+++ b/public/templates/css/futuristic.css
@@ -23,6 +23,11 @@ body.futuristic-template {
     font-size: 13px;
     line-height: 1.75;
     padding: 56px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .futuristic-grid {
@@ -283,6 +288,8 @@ body.futuristic-template {
     body.futuristic-template {
         padding: 0;
         background: #000000;
+        min-height: auto;
+        display: block;
     }
 
     .futuristic-grid {

--- a/public/templates/css/gradient.css
+++ b/public/templates/css/gradient.css
@@ -20,6 +20,11 @@ body.gradient-template {
     font-size: 13px;
     line-height: 1.7;
     padding: 60px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .gradient-wrapper {
@@ -246,6 +251,8 @@ body.gradient-template {
     body.gradient-template {
         padding: 0;
         background: #ffffff;
+        min-height: auto;
+        display: block;
     }
 
     .gradient-wrapper {

--- a/public/templates/css/minimal.css
+++ b/public/templates/css/minimal.css
@@ -21,6 +21,11 @@ body.minimal-template {
     font-size: 14px;
     line-height: 1.7;
     padding: 64px 48px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .minimal-wrapper {
@@ -333,5 +338,20 @@ body.minimal-template {
     .minimal-education__details {
         flex-direction: column;
         align-items: flex-start;
+    }
+}
+
+@media print {
+    body.minimal-template {
+        padding: 0;
+        background: #ffffff;
+        min-height: auto;
+        display: block;
+    }
+
+    .minimal-wrapper {
+        border-radius: 0;
+        box-shadow: none;
+        border: none;
     }
 }

--- a/public/templates/css/modern.css
+++ b/public/templates/css/modern.css
@@ -21,6 +21,11 @@ body.modern-template {
     font-size: 13px;
     line-height: 1.75;
     padding: 56px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 .modern-shell {
@@ -246,6 +251,8 @@ body.modern-template {
     body.modern-template {
         padding: 0;
         background: #ffffff;
+        min-height: auto;
+        display: block;
     }
 
     .modern-shell {


### PR DESCRIPTION
## Summary
- anchor each resume template’s body as a flex column so the main page container rests at the bottom of the viewport
- add print overrides to revert the flex layout and preserve existing PDF output styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5fbb05d7083328559a71465feb248