### PR TITLE
Improve create CV mobile layout

### DIFF
--- a/resources/js/cv-form.js
+++ b/resources/js/cv-form.js
@@ -10,6 +10,11 @@ const initCvForm = () => {
     const nextButton = document.getElementById('nextStep');
     const prevButton = document.getElementById('prevStep');
     const submitButton = document.getElementById('submitStep');
+    const stepProgress = document.querySelector('[data-step-progress]');
+    const stepMobileLabel = document.querySelector('[data-step-mobile-label]');
+    const stepLabelTemplate = stepMobileLabel?.dataset.stepLabelTemplate ?? null;
+    const stepMobileTitle = document.querySelector('[data-step-mobile-title]');
+    const stepMobileSubtitle = document.querySelector('[data-step-mobile-subtitle]');
     const totalSteps = stepPanels.length;
     const isEditing = form.dataset.isEditing === 'true';
     let currentStep = 1;
@@ -175,12 +180,29 @@ const initCvForm = () => {
             button.classList.toggle('cursor-pointer', isVisited);
             button.classList.toggle('cursor-not-allowed', !isVisited);
             button.disabled = !isVisited;
+            button.tabIndex = isVisited ? 0 : -1;
+            button.setAttribute('aria-current', isActive ? 'step' : 'false');
+            button.setAttribute('aria-disabled', (!isVisited).toString());
+            button.classList.toggle('opacity-60', !isVisited && !isActive);
+            button.classList.toggle('opacity-100', isVisited || isActive);
+            button.classList.toggle('bg-white', isActive && !hasError);
+            button.classList.toggle('bg-white/70', !isActive && !hasError);
+            button.classList.toggle('bg-red-50', hasError);
+            button.classList.toggle('shadow-lg', isActive && !hasError);
+            button.classList.toggle('shadow-sm', !isActive || hasError);
+            button.classList.toggle('border-violet-200', isActive && !hasError);
+            button.classList.toggle('border-slate-200/80', !hasError && !isActive);
+            button.classList.toggle('border-red-300', hasError);
+            button.classList.toggle('ring-2', isActive);
+            button.classList.toggle('ring-violet-200', isActive && !hasError);
+            button.classList.toggle('ring-red-200', isActive && hasError);
+            button.classList.toggle('ring-0', !isActive);
 
             if (!circle) {
                 return;
             }
 
-            circle.className = 'flex h-12 w-12 items-center justify-center rounded-full border text-base font-semibold shadow-sm transition-all duration-300';
+            circle.className = 'flex h-12 w-12 shrink-0 items-center justify-center rounded-full border text-base font-semibold shadow-sm transition-all duration-300';
             if (hasError) {
                 circle.classList.add('bg-white', 'text-red-600', 'border-red-400', 'ring-2', 'ring-red-200');
             } else if (step < currentStep) {
@@ -191,6 +213,32 @@ const initCvForm = () => {
                 circle.classList.add('bg-white', 'text-slate-400', 'border-slate-200');
             }
         });
+
+        const activeButton =
+            stepButtons.find((button) => Number(button.dataset.stepTrigger) === currentStep) ?? null;
+
+        if (stepProgress) {
+            const progressPercent = Math.max((currentStep / totalSteps) * 100, 0);
+            stepProgress.style.width = `${progressPercent}%`;
+        }
+
+        if (stepMobileLabel) {
+            if (stepLabelTemplate) {
+                stepMobileLabel.textContent = stepLabelTemplate
+                    .replace(':current', String(currentStep))
+                    .replace(':total', String(totalSteps));
+            } else {
+                stepMobileLabel.textContent = `Step ${currentStep} of ${totalSteps}`;
+            }
+        }
+
+        if (stepMobileTitle) {
+            stepMobileTitle.textContent = activeButton?.dataset.stepTitle ?? '';
+        }
+
+        if (stepMobileSubtitle) {
+            stepMobileSubtitle.textContent = activeButton?.dataset.stepDescription ?? '';
+        }
 
         connectors.forEach((connector) => {
             const index = Number(connector.dataset.stepConnector);

--- a/resources/views/cv/form.blade.php
+++ b/resources/views/cv/form.blade.php
@@ -31,6 +31,9 @@
             ['title' => 'Template', 'description' => 'Pick a visual style'],
         ];
 
+        $totalSteps = max(count($stepItems), 1);
+        $firstStep = $stepItems[0] ?? ['title' => '', 'description' => ''];
+
         $templateMeta = [
             'classic' => [
                 'title' => 'Classic',
@@ -323,13 +326,22 @@
 
     <div class="min-h-screen -mx-4 -mt-8 bg-gradient-to-br from-slate-100 via-white to-slate-200 px-4 py-10 sm:px-6 lg:px-8">
         <div class="max-w-5xl mx-auto">
-            <div class="text-center text-slate-900 mb-12">
-                
-                <h1 class="mt-5 text-4xl md:text-5xl font-semibold tracking-tight">{{ $headline }}</h1>
-                <p class="mt-3 text-base md:text-lg text-slate-500">{{ $heroSubtitle }}</p>
-                @if ($isEditing && $editingTitle)
-                    <p class="mt-2 text-sm font-medium text-slate-500">{{ __('Working on: :title', ['title' => $editingTitle]) }}</p>
-                @endif
+            <div class="mb-12 text-slate-900">
+                <div class="mx-auto max-w-3xl space-y-4 text-center sm:text-left">
+                    <span class="inline-flex items-center gap-2 rounded-full bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-600 shadow-sm ring-1 ring-white/60 backdrop-blur-sm">
+                        <span class="h-2 w-2 rounded-full bg-violet-400"></span>
+                        {{ $badgeLabel }}
+                    </span>
+                    <div class="space-y-3">
+                        <h1 class="text-3xl font-semibold tracking-tight sm:text-4xl md:text-5xl">{{ $headline }}</h1>
+                        <p class="text-base text-slate-500 sm:text-lg">{{ $heroSubtitle }}</p>
+                        @if ($isEditing && $editingTitle)
+                            <p class="text-sm font-medium text-slate-500">
+                                {{ __('Working on: :title', ['title' => $editingTitle]) }}
+                            </p>
+                        @endif
+                    </div>
+                </div>
             </div>
 
             @if ($errors->any())
@@ -345,21 +357,49 @@
 
             <div class="bg-white/95 backdrop-blur-xl shadow-xl rounded-[32px] p-6 sm:p-10 md:p-12" data-scroll-anchor="cv-form-container">
                 <div class="mb-12">
-                    <div class="flex flex-col gap-6 md:flex-row md:items-center md:gap-4">
-                        @foreach ($stepItems as $index => $step)
-                            <div class="flex items-center gap-4 md:flex-1">
-                                <button type="button" data-step-trigger="{{ $loop->iteration }}" class="flex flex-col md:flex-row md:items-center text-slate-500 gap-2 transition" aria-label="Step {{ $loop->iteration }}: {{ $step['title'] }}">
-                                    <span data-step-circle class="flex h-12 w-12 items-center justify-center rounded-full border border-slate-200 bg-white text-base font-semibold shadow-sm transition-all duration-300">{{ $loop->iteration }}</span>
-                                    <span class="flex flex-col text-left md:text-left">
-                                        <span class="text-sm font-semibold">{{ $step['title'] }}</span>
-                                        <span class="text-xs text-slate-400">{{ $step['description'] }}</span>
-                                    </span>
-                                </button>
-                                @if (!$loop->last)
-                                    <div data-step-connector="{{ $loop->iteration }}" class="hidden md:block flex-1 h-0.5 bg-slate-200 rounded-full transition-colors duration-300"></div>
-                                @endif
-                            </div>
-                        @endforeach
+                    <div class="relative -mx-6 overflow-x-auto pb-6 md:mx-0 md:overflow-visible md:pb-0" data-stepper-region>
+                        <div class="flex min-w-max snap-x snap-mandatory gap-4 px-6 md:min-w-0 md:flex-1 md:items-center md:gap-6 md:px-0">
+                            @foreach ($stepItems as $index => $step)
+                                <div class="flex snap-start items-stretch gap-4 md:flex-1 md:items-center">
+                                    <button
+                                        type="button"
+                                        data-step-trigger="{{ $loop->iteration }}"
+                                        data-step-title="{{ $step['title'] }}"
+                                        data-step-description="{{ $step['description'] }}"
+                                        class="group flex min-w-[220px] flex-col gap-3 rounded-3xl border border-slate-200/80 bg-white/70 px-5 py-4 text-left text-slate-500 shadow-sm transition hover:border-violet-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-200 md:min-w-0 md:flex-row md:items-center md:gap-4 md:rounded-none md:border-none md:bg-transparent md:px-0 md:py-0 md:text-left md:shadow-none md:hover:border-none md:hover:shadow-none md:focus-visible:ring-0 md:ring-0"
+                                        aria-label="Step {{ $loop->iteration }}: {{ $step['title'] }}"
+                                    >
+                                        <div class="flex items-center gap-3 md:gap-4">
+                                            <span data-step-circle>{{ $loop->iteration }}</span>
+                                            <span class="flex flex-col text-left">
+                                                <span class="text-sm font-semibold md:text-base">{{ $step['title'] }}</span>
+                                                <span class="text-xs text-slate-400">{{ $step['description'] }}</span>
+                                            </span>
+                                        </div>
+                                    </button>
+                                    @if (!$loop->last)
+                                        <div data-step-connector="{{ $loop->iteration }}" class="hidden h-0.5 flex-1 rounded-full bg-slate-200 transition-colors duration-300 md:block"></div>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
+                    <div class="space-y-3 md:hidden">
+                        <div class="flex items-center justify-between">
+                            <span
+                                data-step-mobile-label
+                                data-step-label-template="{{ __('Step :current of :total', ['current' => ':current', 'total' => ':total']) }}"
+                                class="text-xs font-medium uppercase tracking-[0.3em] text-slate-400"
+                                aria-live="polite"
+                            >
+                                {{ __('Step :current of :total', ['current' => 1, 'total' => $totalSteps]) }}
+                            </span>
+                            <span data-step-mobile-title class="text-sm font-semibold text-slate-700" aria-live="polite">{{ $firstStep['title'] ?? '' }}</span>
+                        </div>
+                        <div class="h-1.5 w-full overflow-hidden rounded-full bg-slate-200/80">
+                            <div data-step-progress class="h-full rounded-full bg-violet-500 transition-all duration-300 ease-out" style="width: {{ 100 / $totalSteps }}%"></div>
+                        </div>
+                        <p data-step-mobile-subtitle class="text-xs text-slate-500" aria-live="polite">{{ $firstStep['description'] ?? '' }}</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Refine the create CV hero and stepper layout for smaller screens with new badge, spacing, and mobile progress indicators
- Enhance the step navigation buttons with better state styling and accessibility metadata while preserving desktop connectors
- Sync the stepper script with mobile progress updates, responsive styling toggles, and richer aria attributes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e61496322c8332bbc7d13247de5a88