### PR TITLE
Remove default PDF page margins

### DIFF
--- a/resources/views/cv/pdf/layout.blade.php
+++ b/resources/views/cv/pdf/layout.blade.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>{{ trim(($data['first_name'] ?? '') . ' ' . ($data['last_name'] ?? '')) ?: 'CV' }}</title>
     <style>
-        @page { margin: 36px; }
+        @page { margin: 0; }
         * { box-sizing: border-box; }
         body {
             margin: 0;


### PR DESCRIPTION
## Summary
- set the PDF page margin to zero so the exported resume fills the entire page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e896495dec83328efaafe60bac1959