### PR TITLE
Adjust template previews to avoid scrollbars

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -410,11 +410,13 @@
     }
 
     .createit-template-card__preview {
-        @apply relative h-64 overflow-hidden rounded-t-[28px] bg-white sm:h-72;
+        @apply relative overflow-hidden rounded-t-[28px] bg-white;
+        aspect-ratio: 8.5 / 11;
+        max-height: 32rem;
     }
 
     .createit-template-card__preview-frame {
-        @apply h-full w-full border-0;
+        @apply h-full w-full border-0 pointer-events-none;
     }
 
     .createit-template-card__badge {
@@ -445,8 +447,12 @@
         @apply inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-blue-500 hover:text-blue-600;
     }
 
+    .createit-template-preview {
+        aspect-ratio: 8.5 / 11;
+    }
+
     .createit-template-preview__inner {
-        @apply h-full w-full overflow-hidden;
+        @apply absolute inset-3 overflow-hidden rounded-3xl bg-white shadow-lg sm:inset-4;
     }
 
     .createit-template-preview__frame {

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -393,7 +393,7 @@
                         <p class="text-xs uppercase tracking-[0.35em] text-slate-400">{{ __('Template') }}</p>
                         <h2 class="text-lg font-semibold text-slate-900">{{ $templateInfo['title'] }}</h2>
                         <p class="text-sm text-slate-600">{{ $templateInfo['description'] }}</p>
-                        <div class="createit-template-preview relative mt-4 h-52 overflow-hidden rounded-2xl bg-gradient-to-br {{ $templateInfo['preview'] }} shadow-inner shadow-slate-400/20">
+                        <div class="createit-template-preview relative mt-4 overflow-hidden rounded-2xl bg-gradient-to-br {{ $templateInfo['preview'] }} shadow-inner shadow-slate-400/20">
                             <div class="createit-template-preview__inner">
                                 <iframe
                                     src="{{ $pdfPreviewUrl }}#toolbar=0&navpanes=0&scrollbar=0&zoom=page-fit"

--- a/resources/views/cv/templates.blade.php
+++ b/resources/views/cv/templates.blade.php
@@ -84,6 +84,7 @@
                             src="{{ route('cv.template-preview', $template) }}#toolbar=0&navpanes=0&scrollbar=0&zoom=page-fit"
                             title="{{ __('Preview of the :template template', ['template' => $meta['title']]) }}"
                             class="createit-template-card__preview-frame"
+                            scrolling="no"
                             loading="lazy"
                         >
                             {{ __('PDF preview of the :template template.', ['template' => $meta['title']]) }}


### PR DESCRIPTION
## Summary
- keep template card previews within an 8.5:11 aspect ratio so the full layout shows without scrolling
- update the dashboard template preview frame to share the same sizing treatment and remove fixed heights
- disable pointer interaction on embedded previews to prevent accidental iframe scrolling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8ac4464948332b1d5b132927deb95