### PR TITLE
Hide template preview scrollbars

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -417,6 +417,11 @@
 
     .createit-template-card__preview-frame {
         @apply h-full w-full border-0 pointer-events-none;
+        scrollbar-width: none;
+    }
+
+    .createit-template-card__preview-frame::-webkit-scrollbar {
+        display: none;
     }
 
     .createit-template-card__badge {


### PR DESCRIPTION
## Summary
- hide the PDF iframe scrollbars in the templates gallery by extending the preview frame styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8b2bce37c83328a5705df96e3e450