### PR TITLE
Revamp alert styling across the app

### DIFF
--- a/resources/css/createit.css
+++ b/resources/css/createit.css
@@ -109,15 +109,69 @@
     }
 
     .createit-alert {
-        @apply rounded-2xl border px-4 py-3 text-sm;
+        @apply relative flex items-start gap-4 overflow-hidden rounded-3xl border border-transparent bg-white/80 px-5 py-4 text-sm font-medium text-slate-700 shadow-lg shadow-slate-900/5 ring-1 ring-inset transition;
+        @apply backdrop-blur;
+    }
+
+    .createit-alert::after {
+        content: "";
+        position: absolute;
+        top: 0.65rem;
+        bottom: 0.65rem;
+        right: -2.5rem;
+        width: 8rem;
+        border-radius: 9999px;
+        background: linear-gradient(110deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
+        pointer-events: none;
+        filter: blur(0.5px);
+    }
+
+    .createit-alert__icon {
+        @apply mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl bg-white/70 text-lg shadow-inner shadow-white/40 ring-1 ring-inset ring-white/60;
+    }
+
+    .createit-alert__content {
+        @apply flex-1 space-y-1 text-left;
+    }
+
+    .createit-alert__title {
+        @apply text-sm font-semibold tracking-tight;
+    }
+
+    .createit-alert__message {
+        @apply space-y-2 text-sm font-medium leading-relaxed text-inherit;
     }
 
     .createit-alert--success {
-        @apply border-emerald-200 bg-emerald-50/80 text-emerald-700;
+        @apply border-emerald-300/70 bg-emerald-50/80 text-emerald-800 ring-emerald-500/25;
+    }
+
+    .createit-alert--success .createit-alert__icon {
+        @apply text-emerald-600 ring-emerald-400/40;
     }
 
     .createit-alert--error {
-        @apply border-red-200 bg-red-50/80 text-red-700;
+        @apply border-rose-300/70 bg-rose-50/80 text-rose-800 ring-rose-500/20;
+    }
+
+    .createit-alert--error .createit-alert__icon {
+        @apply text-rose-600 ring-rose-400/40;
+    }
+
+    .createit-alert--info {
+        @apply border-sky-300/70 bg-sky-50/80 text-sky-800 ring-sky-500/20;
+    }
+
+    .createit-alert--info .createit-alert__icon {
+        @apply text-sky-600 ring-sky-400/40;
+    }
+
+    .createit-alert--warning {
+        @apply border-amber-300/70 bg-amber-50/80 text-amber-800 ring-amber-500/20;
+    }
+
+    .createit-alert--warning .createit-alert__icon {
+        @apply text-amber-600 ring-amber-400/40;
     }
 
     .createit-social {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -7,15 +7,15 @@
         </div>
 
         @if (session('status'))
-            <div class="createit-alert createit-alert--success">
+            <x-alert type="success" :title="false">
                 {{ session('status') }}
-            </div>
+            </x-alert>
         @endif
 
         @if (session('oauth_error'))
-            <div class="createit-alert createit-alert--error">
+            <x-alert type="error">
                 {{ session('oauth_error') }}
-            </div>
+            </x-alert>
         @endif
 
         <x-auth.social-providers intent="login" />

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -7,9 +7,9 @@
         </div>
 
         @if (session('oauth_error'))
-            <div class="createit-alert createit-alert--error">
+            <x-alert type="error">
                 {{ session('oauth_error') }}
-            </div>
+            </x-alert>
         @endif
 
         <x-auth.social-providers intent="register" />

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -4,9 +4,9 @@
     </div>
 
     @if (session('status') == 'verification-link-sent')
-        <div class="mb-4 font-medium text-sm text-green-600">
+        <x-alert type="success" class="mb-6" title="{{ __('Verification link sent') }}">
             {{ __('A new verification link has been sent to the email address you provided during registration.') }}
-        </div>
+        </x-alert>
     @endif
 
     <div class="mt-4 flex items-center justify-between">

--- a/resources/views/components/alert.blade.php
+++ b/resources/views/components/alert.blade.php
@@ -1,0 +1,57 @@
+@props([
+    'type' => 'info',
+    'title' => null,
+])
+
+@php
+    $variant = in_array($type, ['success', 'error', 'warning', 'info'], true)
+        ? $type
+        : 'info';
+
+    $icons = [
+        'success' => 'M4.5 12.75 9 17.25 19.5 6.75',
+        'error' => 'M15 9l-6 6m0-6 6 6',
+        'warning' => 'M12 9v3.75m0 3.75h.008v.008H12V16.5Z',
+        'info' => 'M11.25 11.25h1.5v5.25h-1.5m0-7.5h1.5',
+    ];
+
+    $viewBoxes = [
+        'success' => '0 0 24 24',
+        'error' => '0 0 24 24',
+        'warning' => '0 0 24 24',
+        'info' => '0 0 24 24',
+    ];
+
+    $titles = [
+        'success' => __('Success'),
+        'error' => __('Error'),
+        'warning' => __('Heads up'),
+        'info' => __('Notice'),
+    ];
+
+    $iconPath = $icons[$variant];
+    $iconViewBox = $viewBoxes[$variant];
+    $fallbackTitle = $titles[$variant];
+    $showTitle = $title !== false;
+    $resolvedTitle = $showTitle ? ($title ?? $fallbackTitle) : null;
+@endphp
+
+<div {{ $attributes->merge(['class' => 'createit-alert createit-alert--' . $variant, 'role' => 'alert']) }}>
+    <div class="createit-alert__icon" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="{{ $iconViewBox }}" fill="none" stroke="currentColor" stroke-width="1.5" class="h-5 w-5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="{{ $iconPath }}" />
+        </svg>
+    </div>
+
+    <div class="createit-alert__content">
+        @if ($showTitle)
+            <p class="createit-alert__title">
+                {{ $resolvedTitle }}
+            </p>
+        @endif
+
+        <div class="createit-alert__message">
+            {{ $slot }}
+        </div>
+    </div>
+</div>

--- a/resources/views/components/auth-session-status.blade.php
+++ b/resources/views/components/auth-session-status.blade.php
@@ -1,7 +1,11 @@
-@props(['status'])
+@props([
+    'status',
+    'type' => 'success',
+    'title' => null,
+])
 
 @if ($status)
-    <div {{ $attributes->merge(['class' => 'font-medium text-sm text-green-600']) }}>
+    <x-alert :type="$type" :title="$title" {{ $attributes }}>
         {{ $status }}
-    </div>
+    </x-alert>
 @endif

--- a/resources/views/cv/history.blade.php
+++ b/resources/views/cv/history.blade.php
@@ -28,9 +28,9 @@
         </div>
 
         @if (session('status'))
-            <div class="rounded-3xl border border-emerald-200 bg-emerald-50/80 px-6 py-4 text-sm text-emerald-700 shadow-sm">
+            <x-alert type="success" :title="false">
                 {{ session('status') }}
-            </div>
+            </x-alert>
         @endif
 
         @if ($entries->isEmpty())

--- a/resources/views/cv/preview.blade.php
+++ b/resources/views/cv/preview.blade.php
@@ -3,9 +3,9 @@
 
     <div class="space-y-8">
         @if (session('status'))
-            <div class="rounded-3xl border border-emerald-200 bg-emerald-50/80 p-6 text-sm text-emerald-800 shadow-sm">
+            <x-alert type="success" :title="false">
                 {{ session('status') }}
-            </div>
+            </x-alert>
         @endif
 
         @if (!empty($cvData))

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -46,13 +46,17 @@
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
             @if (session('status') === 'password-updated')
-                <p
+                <x-alert
+                    type="success"
+                    :title="false"
+                    class="mt-3 w-full sm:w-auto"
                     x-data="{ show: true }"
                     x-show="show"
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm font-medium text-emerald-600"
-                >{{ __('Saved.') }}</p>
+                >
+                    {{ __('Password updated successfully!') }}
+                </x-alert>
             @endif
         </div>
     </form>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -51,12 +51,15 @@
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
             @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
-                <div class="mt-4 rounded-2xl bg-amber-50 px-4 py-3 text-sm text-amber-700">
-                    <p class="font-medium">
+                <x-alert type="warning" class="mt-4" title="{{ __('Email verification needed') }}">
+                    <span class="block text-sm">
                         {{ __('Your email address is unverified.') }}
-                    </p>
+                    </span>
 
-                    <button form="send-verification" class="mt-2 inline-flex items-center gap-2 rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white transition hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-2 focus:ring-offset-amber-100">
+                    <button
+                        form="send-verification"
+                        class="mt-3 inline-flex items-center gap-2 rounded-full bg-amber-600 px-4 py-2 text-xs font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-2 focus:ring-offset-amber-100"
+                    >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25 12 13.5l9-5.25M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
                         </svg>
@@ -64,11 +67,14 @@
                     </button>
 
                     @if (session('status') === 'verification-link-sent')
-                        <p class="mt-2 font-medium text-amber-700">
-                            {{ __('A new verification link has been sent to your email address.') }}
-                        </p>
+                        <span class="mt-3 inline-flex items-center gap-2 rounded-full bg-white/60 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-700">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" class="h-4 w-4">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75 9 17.25 19.5 6.75" />
+                            </svg>
+                            {{ __('Verification email sent') }}
+                        </span>
                     @endif
-                </div>
+                </x-alert>
             @endif
         </div>
 
@@ -132,13 +138,17 @@
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
             @if (session('status') === 'profile-updated')
-                <p
+                <x-alert
+                    type="success"
+                    :title="false"
+                    class="mt-3 w-full sm:w-auto"
                     x-data="{ show: true }"
                     x-show="show"
                     x-transition
                     x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm font-medium text-emerald-600"
-                >{{ __('Saved.') }}</p>
+                >
+                    {{ __('Profile saved successfully!') }}
+                </x-alert>
             @endif
         </div>
     </form>


### PR DESCRIPTION
## Summary
- add a reusable alert Blade component with icons, optional titles, and variants
- refresh the CreateIt alert styles to use a richer layout with gradients and backdrop blur
- replace inline alert markup across auth, CV, and profile screens with the new component for consistent messaging

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e8b696d0e483329681843677b5d5c7